### PR TITLE
Handling of different eclipse types

### DIFF
--- a/src/solareclipseworkbench/camera.py
+++ b/src/solareclipseworkbench/camera.py
@@ -291,12 +291,14 @@ def get_camera_overview() -> dict:
     camera_names = get_cameras()
 
     for camera_name in camera_names:
+        try:
+            battery_level = get_battery_level(camera_name[0])
+            free_space = get_free_space(camera_name[0])
+            total_space = get_space(camera_name[0])
 
-        battery_level = get_battery_level(camera_name[0])
-        free_space = get_free_space(camera_name[0])
-        total_space = get_space(camera_name[0])
-
-        camera_overview[camera_name[0]] = CameraInfo(camera_name, battery_level, free_space, total_space)
+            camera_overview[camera_name[0]] = CameraInfo(camera_name, battery_level, free_space, total_space)
+        except gp.GPhoto2Error as error:
+            logging.warning(f"Photo2Error occurred for {camera_name[0]} ({error.string})")
 
     return camera_overview
 

--- a/src/solareclipseworkbench/camera.py
+++ b/src/solareclipseworkbench/camera.py
@@ -277,7 +277,7 @@ def __set_datetime(config) -> bool:
     return False
 
 
-def get_camera_overview():
+def get_camera_overview() -> dict:
     """ Returns a dictionary with information of the connected cameras.
 
     The keys in the dictionary are the camera names and the values (the camera information) contains information about
@@ -301,7 +301,7 @@ def get_camera_overview():
     return camera_overview
 
 
-class CameraInfo():
+class CameraInfo:
 
     def __init__(self, camera_name: str, battery_level: float, free_space: float, total_space: float) -> None:
         """ Create a new CameraInfo object.

--- a/src/solareclipseworkbench/gui.py
+++ b/src/solareclipseworkbench/gui.py
@@ -346,10 +346,14 @@ class SolarEclipseView(QMainWindow, Observable):
         self.time_label_utc.setText(
             f"{datetime.datetime.strftime(current_time_utc, TIME_FORMATS[self.time_format])}{suffix}")
 
-    def show_reference_moments(self, reference_moments: dict):
-        suffix = ""
-        # if self.time_format == "12 hours":
-        #     suffix = " am" if current_time_utc.hour < 12 else " pm"
+    def show_reference_moments(self, reference_moments: dict, magnitude: float):
+
+        if magnitude == 0:
+            self.eclipse_type.setText("No eclipse")
+        elif magnitude == 1:
+            self.eclipse_type.setText("Total eclipse")
+        else:
+            self.eclipse_type.setText(f"Partial eclipse (magnitude: {round(magnitude, 2)})")
 
         suffix = ""
 

--- a/src/solareclipseworkbench/gui.py
+++ b/src/solareclipseworkbench/gui.py
@@ -84,17 +84,37 @@ class SolarEclipseModel:
 
     def get_reference_moments(self):
 
-        reference_moments, _ = calculate_reference_moments(self.longitude, self.latitude, self.altitude,
-                                                           self.eclipse_date)
-        self.c1_info = reference_moments["C1"]
-        self.c2_info = reference_moments["C2"]
-        self.max_info = reference_moments["MAX"]
-        self.c3_info = reference_moments["C3"]
-        self.c4_info = reference_moments["C4"]
+        reference_moments, magnitude = calculate_reference_moments(self.longitude, self.latitude, self.altitude,
+                                                                   self.eclipse_date)
+
+        # No eclipse
+
+        if magnitude == 0:
+            self.c1_info = None
+            self.c2_info = None
+            self.max_info = None
+            self.c3_info = None
+            self.c4_info = None
+
+        # Partial / total eclipse
+
+        elif magnitude > 0:
+            self.c1_info = reference_moments["C1"]
+            self.c2_info = None
+            self.max_info = reference_moments["MAX"]
+            self.c3_info = None
+            self.c4_info = reference_moments["C4"]
+
+        # Total eclipse
+
+        if magnitude == 1:
+            self.c2_info = reference_moments["C2"]
+            self.c3_info = reference_moments["C3"]
+
         self.sunrise_info = reference_moments["sunrise"]
         self.sunset_info = reference_moments["sunset"]
 
-        return reference_moments
+        return reference_moments, magnitude
 
     def set_camera_overview(self):
 
@@ -337,54 +357,85 @@ class SolarEclipseView(QMainWindow, Observable):
         #     f"{datetime.datetime.strftime(current_time_local, TIME_FORMATS[self.time_format])}{suffix}")
         # self.time_label_utc.setText(
         #     f"{datetime.datetime.strftime(current_time_utc, TIME_FORMATS[self.time_format])}{suffix}")
+        suffix = ""
 
         # First contact
 
-        c1_info: ReferenceMomentInfo = reference_moments["C1"]
-        self.c1_time_utc_label.setText(f"{datetime.datetime.strftime(c1_info.time_utc, TIME_FORMATS[self.time_format])}{suffix}")
-        self.c1_time_local_label.setText(
-            f"{datetime.datetime.strftime(c1_info.time_local, TIME_FORMATS[self.time_format])}{suffix}")
-        self.c1_azimuth_label.setText(str(int(c1_info.azimuth)))
-        self.c1_altitude_label.setText(str(int(c1_info.altitude)))
+        if "C1" in reference_moments:
+            c1_info: ReferenceMomentInfo = reference_moments["C1"]
+            self.c1_time_utc_label.setText(f"{datetime.datetime.strftime(c1_info.time_utc, TIME_FORMATS[self.time_format])}{suffix}")
+            self.c1_time_local_label.setText(
+                f"{datetime.datetime.strftime(c1_info.time_local, TIME_FORMATS[self.time_format])}{suffix}")
+            self.c1_azimuth_label.setText(str(int(c1_info.azimuth)))
+            self.c1_altitude_label.setText(str(int(c1_info.altitude)))
+        else:
+            self.c1_time_utc_label.setText("")
+            self.c1_time_local_label.setText("")
+            self.c1_azimuth_label.setText("")
+            self.c1_altitude_label.setText("")
 
         # Second contact
 
-        c2_info: ReferenceMomentInfo = reference_moments["C2"]
-        self.c2_time_utc_label.setText(
-            f"{datetime.datetime.strftime(c2_info.time_utc, TIME_FORMATS[self.time_format])}{suffix}")
-        self.c2_time_local_label.setText(
-            f"{datetime.datetime.strftime(c2_info.time_local, TIME_FORMATS[self.time_format])}{suffix}")
-        self.c2_azimuth_label.setText(str(int(c2_info.azimuth)))
-        self.c2_altitude_label.setText(str(int(c2_info.altitude)))
+        if "C2" in reference_moments:
+            c2_info: ReferenceMomentInfo = reference_moments["C2"]
+            self.c2_time_utc_label.setText(
+                f"{datetime.datetime.strftime(c2_info.time_utc, TIME_FORMATS[self.time_format])}{suffix}")
+            self.c2_time_local_label.setText(
+                f"{datetime.datetime.strftime(c2_info.time_local, TIME_FORMATS[self.time_format])}{suffix}")
+            self.c2_azimuth_label.setText(str(int(c2_info.azimuth)))
+            self.c2_altitude_label.setText(str(int(c2_info.altitude)))
+        else:
+            self.c2_time_utc_label.setText("")
+            self.c2_time_local_label.setText("")
+            self.c2_azimuth_label.setText("")
+            self.c2_altitude_label.setText("")
 
         # Maximum eclipse
 
-        max_info: ReferenceMomentInfo = reference_moments["MAX"]
-        self.max_time_utc_label.setText(
-            f"{datetime.datetime.strftime(max_info.time_utc, TIME_FORMATS[self.time_format])}{suffix}")
-        self.max_time_local_label.setText(
-            f"{datetime.datetime.strftime(max_info.time_local, TIME_FORMATS[self.time_format])}{suffix}")
-        self.max_azimuth_label.setText(str(int(max_info.azimuth)))
-        self.max_altitude_label.setText(str(int(max_info.altitude)))
+        if "MAX" in reference_moments:
+            max_info: ReferenceMomentInfo = reference_moments["MAX"]
+            self.max_time_utc_label.setText(
+                f"{datetime.datetime.strftime(max_info.time_utc, TIME_FORMATS[self.time_format])}{suffix}")
+            self.max_time_local_label.setText(
+                f"{datetime.datetime.strftime(max_info.time_local, TIME_FORMATS[self.time_format])}{suffix}")
+            self.max_azimuth_label.setText(str(int(max_info.azimuth)))
+            self.max_altitude_label.setText(str(int(max_info.altitude)))
+        else:
+            self.max_time_utc_label.setText("")
+            self.max_time_local_label.setText("")
+            self.max_azimuth_label.setText("")
+            self.max_altitude_label.setText("")
 
         # Third contact
 
-        c3_info: ReferenceMomentInfo = reference_moments["C3"]
-        self.c3_time_utc_label.setText(f"{datetime.datetime.strftime(c3_info.time_utc, TIME_FORMATS[self.time_format])}{suffix}")
-        self.c3_time_local_label.setText(
-            f"{datetime.datetime.strftime(c3_info.time_local, TIME_FORMATS[self.time_format])}{suffix}")
-        self.c3_azimuth_label.setText(str(int(c3_info.azimuth)))
-        self.c3_altitude_label.setText(str(int(c3_info.altitude)))
+        if "C3" in reference_moments:
+            c3_info: ReferenceMomentInfo = reference_moments["C3"]
+            self.c3_time_utc_label.setText(f"{datetime.datetime.strftime(c3_info.time_utc, TIME_FORMATS[self.time_format])}{suffix}")
+            self.c3_time_local_label.setText(
+                f"{datetime.datetime.strftime(c3_info.time_local, TIME_FORMATS[self.time_format])}{suffix}")
+            self.c3_azimuth_label.setText(str(int(c3_info.azimuth)))
+            self.c3_altitude_label.setText(str(int(c3_info.altitude)))
+        else:
+            self.c3_time_utc_label.setText("")
+            self.c3_time_local_label.setText("")
+            self.c3_azimuth_label.setText("")
+            self.c3_altitude_label.setText("")
 
         # Fourth contact
 
-        c4_info: ReferenceMomentInfo = reference_moments["C4"]
-        self.c4_time_utc_label.setText(
-            f"{datetime.datetime.strftime(c4_info.time_utc, TIME_FORMATS[self.time_format])}{suffix}")
-        self.c4_time_local_label.setText(
-            f"{datetime.datetime.strftime(c4_info.time_local, TIME_FORMATS[self.time_format])}{suffix}")
-        self.c4_azimuth_label.setText(str(int(c4_info.azimuth)))
-        self.c4_altitude_label.setText(str(int(c4_info.altitude)))
+        if "C4" in reference_moments:
+            c4_info: ReferenceMomentInfo = reference_moments["C4"]
+            self.c4_time_utc_label.setText(
+                f"{datetime.datetime.strftime(c4_info.time_utc, TIME_FORMATS[self.time_format])}{suffix}")
+            self.c4_time_local_label.setText(
+                f"{datetime.datetime.strftime(c4_info.time_local, TIME_FORMATS[self.time_format])}{suffix}")
+            self.c4_azimuth_label.setText(str(int(c4_info.azimuth)))
+            self.c4_altitude_label.setText(str(int(c4_info.altitude)))
+        else:
+            self.c4_time_utc_label.setText("")
+            self.c4_time_local_label.setText("")
+            self.c4_azimuth_label.setText("")
+            self.c4_altitude_label.setText("")
 
         # Sunrise
 
@@ -540,8 +591,8 @@ class SolarEclipseController(Observer):
 
         elif text == "Reference moments":
             if self.model.is_location_set and self.model.is_eclipse_date_set:
-                reference_moments = self.model.get_reference_moments()
-                self.view.show_reference_moments(reference_moments)
+                reference_moments, magnitude = self.model.get_reference_moments()
+                self.view.show_reference_moments(reference_moments, magnitude)
 
         elif text == "Camera(s)":
             # TODO

--- a/src/solareclipseworkbench/gui.py
+++ b/src/solareclipseworkbench/gui.py
@@ -126,7 +126,6 @@ class SolarEclipseView(QMainWindow, Observable):
     def __init__(self):
 
         super().__init__()
-        # self.setWindowIcon(QIcon(str(ICON_PATH / "logo-small.png")))
 
         self.controller = None
 
@@ -183,6 +182,8 @@ class SolarEclipseView(QMainWindow, Observable):
         self.latitude_label.setToolTip("Positive values: Northern hemisphere; Negative values: Southern hemisphere")
         self.altitude_label = QLabel()
 
+        self.eclipse_type = QLabel()
+
         self.init_ui()
 
     def init_ui(self):
@@ -208,11 +209,6 @@ class SolarEclipseView(QMainWindow, Observable):
         place_time_grid_layout.addWidget(self.time_label_local, 2, 1)
         place_time_grid_layout.addWidget(self.time_label_utc, 2, 2)
 
-        # place_time_layout.addLayout(date_layout)
-        # place_time_layout.addLayout(time_layout)
-
-        # self.place_time_frame.setLayout(place_time_layout)
-        # self.place_time_frame.setLayout(grid)
         place_time_group_box.setLayout(place_time_grid_layout)
         vbox_left.addWidget(place_time_group_box)
 
@@ -231,6 +227,8 @@ class SolarEclipseView(QMainWindow, Observable):
         eclipse_date_grid_layout = QGridLayout()
         eclipse_date_grid_layout.addWidget(self.eclipse_date_label, 0, 0)
         eclipse_date_grid_layout.addWidget(self.eclipse_date, 0, 1)
+        eclipse_date_grid_layout.addWidget(QLabel("Eclipse type"), 1, 0)
+        eclipse_date_grid_layout.addWidget(self.eclipse_type, 1, 1)
 
         eclipse_date_group_box.setLayout(eclipse_date_grid_layout)
         vbox_left.addWidget(eclipse_date_group_box)
@@ -353,10 +351,6 @@ class SolarEclipseView(QMainWindow, Observable):
         # if self.time_format == "12 hours":
         #     suffix = " am" if current_time_utc.hour < 12 else " pm"
 
-        # self.time_label_local.setText(
-        #     f"{datetime.datetime.strftime(current_time_local, TIME_FORMATS[self.time_format])}{suffix}")
-        # self.time_label_utc.setText(
-        #     f"{datetime.datetime.strftime(current_time_utc, TIME_FORMATS[self.time_format])}{suffix}")
         suffix = ""
 
         # First contact
@@ -581,12 +575,10 @@ class SolarEclipseController(Observer):
 
         if text == "Location":
             self.location_popup = LocationPopup(self)
-            # self.location_popup.setGeometry(QRect(100, 100, 400, 200))
             self.location_popup.show()
 
         elif text == "Date":
             self.eclipse_popup = EclipsePopup(self)
-            # eclipse_popup.setGeometry(QRect(100, 100, 400, 200))
             self.eclipse_popup.show()
 
         elif text == "Reference moments":
@@ -620,24 +612,6 @@ def main():
     view.show()
 
     return app.exec()
-
-class VLine(QFrame):
-    """Presents a simple Vertical Bar that can be used in e.g. the status bar."""
-
-    def __init__(self):
-        super().__init__()
-        self.setFrameShape(QFrame.VLine | QFrame.Sunken)
-
-
-class HLine(QFrame):
-    """Presents a simple Horizontal Bar that can be used to separate widgets."""
-
-    def __init__(self):
-        super().__init__()
-        self.setLineWidth(0)
-        self.setMidLineWidth(1)
-        self.setFrameShape(QFrame.HLine | QFrame.Sunken)
-
 
 class LocationPopup(QWidget, Observable):
     def __init__(self, observer: SolarEclipseController):


### PR DESCRIPTION
# Summary

- No eclipse:
     - Only show sunrise and sunset;
     - Report "No eclipse" as eclipse type.
- Partial eclipse:
     - Only show C1, MAX, C4, sunset, and sunrise;
     - Report "Partial eclipse" as eclipse type.
- Total eclipse:
     - Show all reference moments (C1, C2, MAX, C3, C4, sunrise, and sunset);
     - Report "Total eclipse" as eclipse type.

# Related issues
#15 

# Test results
Tested different locations with three eclipse types for the total eclipse  of 8/4/2024.  The correct reference moments are shown.  When changing between eclipse types, the information regarding the reference moments is updated (moments that are not applicable are cleared).