### PR TITLE
Synchronisation of the cameras

### DIFF
--- a/src/solareclipseworkbench/gui.py
+++ b/src/solareclipseworkbench/gui.py
@@ -178,9 +178,33 @@ class SolarEclipseModel:
     def sync_camera_time(self):
         """ Set the time of all connected cameras to the time of the computer."""
 
-        raise NotImplementedError
-        # for camera in self.camera_overview:
-        #     set_time(camera)
+        for camera_name, camera in self.camera_overview.items():
+
+            logging.info(f"Syncing time for camera {camera_name}")
+            set_time(camera)
+
+    def check_camera_state(self):
+        """ Check whether the focus mode and shooting mode of all connected cameras is set to 'Manual'.
+
+        For the camera(s) for which the focus mode and/or shooting mode is not set to 'Manual', a warning message is
+        logged.
+        """
+
+        for camera_name, camera in self.camera_overview.items():
+
+            # Focus mode
+
+            focus_mode = get_focus_mode(camera)
+            if focus_mode.lower() != "manual":
+                logging.warning(f"The focus mode for camera {camera_name} should be set to 'Manual' "
+                                f"(is '{focus_mode}')")
+
+            # Shooting mode
+
+            shooting_mode = get_shooting_mode(camera)
+            if shooting_mode.lower() != "manual":
+                logging.warning(f"The shooting mode for camera {camera_name} should be set to 'Manual' "
+                                f"(is '{shooting_mode}')")
 
 
 class SolarEclipseView(QMainWindow, Observable):
@@ -919,6 +943,9 @@ class SolarEclipseController(Observer):
         camera_overview: dict = get_camera_dict()
 
         self.model.set_camera_overview(camera_overview)
+    def sync_camera_time(self):
+        """ Set the time of all connected cameras to the time of the computer."""
+
         self.model.sync_camera_time()
 
         self.view.show_camera_overview(camera_overview)

--- a/src/solareclipseworkbench/gui.py
+++ b/src/solareclipseworkbench/gui.py
@@ -931,6 +931,8 @@ class SolarEclipseController(Observer):
 
         elif text == "Camera(s)":
             self.update_camera_overview()
+            self.sync_camera_time()
+            self.check_camera_state()
 
         elif text == "File":
             print("File")
@@ -940,9 +942,13 @@ class SolarEclipseController(Observer):
             self.settings_popup.show()
 
     def update_camera_overview(self):
+        """ Update the camera overview in the model and the view."""
+
         camera_overview: dict = get_camera_dict()
 
         self.model.set_camera_overview(camera_overview)
+        self.view.show_camera_overview(camera_overview)
+
     def sync_camera_time(self):
         """ Set the time of all connected cameras to the time of the computer."""
 
@@ -1238,8 +1244,22 @@ def main():
     return app.exec()
 
 
-def update_camera_state(controller: SolarEclipseController):
+def sync_cameras(controller: SolarEclipseController):
+    """ Synchronise the cameras for the given controller.
+
+    This consists of the following steps:
+
+        - Update the camera overview in the model and the view of the given controller;
+        - Set the time of all connected cameras to the time of the computer;
+        - Check whether the focus mode and shooting mode of all connected cameras is set to 'Manual'.
+
+    Args:
+        - controller: Controller of the Solar Eclipse Workbench UI
+    """
+
     controller.update_camera_overview()
+    controller.sync_camera_time()
+    controller.check_camera_state()
 
 
 if __name__ == "__main__":

--- a/src/solareclipseworkbench/gui.py
+++ b/src/solareclipseworkbench/gui.py
@@ -948,7 +948,14 @@ class SolarEclipseController(Observer):
 
         self.model.sync_camera_time()
 
-        self.view.show_camera_overview(camera_overview)
+    def check_camera_state(self):
+        """ Check whether the focus mode and shooting mode of all connected cameras is set to 'Manual'.
+
+        For the camera(s) for which the focus mode and/or shooting mode is not set to 'Manual', a warning message is
+        logged.
+        """
+
+        self.model.check_camera_state()
 
 
 class LocationPopup(QWidget, Observable):


### PR DESCRIPTION
# Summary

This consists of the following steps:
- Update the camera overview in the model and the view of the given controller;
- Set the time of all connected cameras to the time of the computer;
- Check whether the focus mode and shooting mode of all connected cameras is set to 'Manual'.

# Test results

Tested with the Canon EOS 80D camera (connected to my laptop) with the incorrect date and time, focus model (AI Servo), and shooting mode (TV).  When the camera button in the toolbar of the UI is clicked, the following happens:
- The date and time of the camera are synchronised with the time of the computer;
- A warning message is logged, reporting that the focus mode was "AI Servo" but should be set to "Manual";
- A warning message is logged, reporting that the shooting mode was "TV" but should be set to "Manual".