### PR TITLE
Start of simulation + Display scheduled jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,3 +226,4 @@ At this moment, Solar Eclipse Workbench only knows a subset of commands from Sol
 - <a href="https://www.flaticon.com/free-icons/settings" title="settings icons">Settings icons created by Freepik - Flaticon</a>
 - <a href="https://www.flaticon.com/free-icons/stop-sign" title="stop sign icons">Stop sign icons created by Freepik - Flaticon</a>
 - <a href="https://www.flaticon.com/free-icons/folder" title="folder icons">Folder icons created by Freepik - Flaticon</a>
+- <a href="https://www.flaticon.com/free-icons/simulation" title="simulation icons">Simulation icons created by Freepik - Flaticon</a>

--- a/src/solareclipseworkbench/gui.py
+++ b/src/solareclipseworkbench/gui.py
@@ -12,7 +12,6 @@ from pathlib import Path
 
 import geopandas
 import pandas as pd
-import pytz
 from PyQt6.QtCore import QTimer, QRect, Qt
 from PyQt6.QtGui import QIcon, QAction, QDoubleValidator
 from PyQt6.QtWidgets import QMainWindow, QApplication, QWidget, QFrame, QLabel, QHBoxLayout, QVBoxLayout, QGridLayout, \
@@ -27,7 +26,7 @@ from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.figure import Figure
 
 from solareclipseworkbench.camera import get_camera_dict, get_battery_level, get_free_space, get_space, \
-    get_shooting_mode, get_focus_mode, set_time
+    get_shooting_mode, get_focus_mode, set_time, CameraSettings
 from solareclipseworkbench.observer import Observer, Observable
 from solareclipseworkbench.reference_moments import calculate_reference_moments, ReferenceMomentInfo
 

--- a/src/solareclipseworkbench/gui.py
+++ b/src/solareclipseworkbench/gui.py
@@ -858,6 +858,8 @@ class SolarEclipseController(Observer):
             - Change in date and/or time format;
             - One of the buttons in the toolbar of the view is clicked.
 
+        Args:
+            - changed_object: Object from which the update was requested
         """
 
         if isinstance(changed_object, LocationPopup):

--- a/src/solareclipseworkbench/gui.py
+++ b/src/solareclipseworkbench/gui.py
@@ -1026,11 +1026,9 @@ class SolarEclipseController(Observer):
                 self.view.jobs_overview.append(f"{job.next_run_time}: {job.name}")
 
         elif text == "Stop":
-            print("Shutdown scheduler")
             try:
                 self.scheduler.shutdown()
                 self.view.jobs_overview.clear()
-                print(self.scheduler.get_jobs())
             except SchedulerNotRunningError:
                 # Scheduler not running
                 pass

--- a/src/solareclipseworkbench/gui.py
+++ b/src/solareclipseworkbench/gui.py
@@ -1023,7 +1023,36 @@ class SolarEclipseController(Observer):
                                                                         self.sim_offset_minutes)
             job: Job
             for job in self.scheduler.get_jobs():
-                self.view.jobs_overview.append(f"{job.next_run_time}: {job.name}")
+
+                job_string = ""
+
+                if job.func.__name__ == "take_picture":
+                    camera_settings: CameraSettings = job.args[1]
+                    camera_name = camera_settings.camera_name
+                    shutter_speed = camera_settings.shutter_speed
+                    aperture = camera_settings.aperture
+                    iso = camera_settings.iso
+
+                    job_string = f"take_picture(\"{camera_name}\", {shutter_speed}, {aperture}, {iso})"
+
+                elif job.func.__name__ == "take_burst":
+                    camera_settings: CameraSettings = job.args[1]
+                    camera_name = camera_settings.camera_name
+                    shutter_speed = camera_settings.shutter_speed
+                    aperture = camera_settings.aperture
+                    iso = camera_settings.iso
+                    duration = job.args[2]
+
+                    job_string = f"take_burst(\"{camera_name}\", {shutter_speed}, {aperture}, {iso}, {duration})"
+
+                elif job.func.__name__ == "sync_cameras":
+                    job_string = f"sync_cameras()"
+
+                elif job.func.__name__ == "voice_prompt":
+                    job_string = f"{job.func.__name__}({', '.join(job.args)})"
+
+                if job.next_run_time:
+                    self.view.jobs_overview.append(f"{job.next_run_time}: {job_string} -> {job.name}")
 
         elif text == "Stop":
             try:

--- a/src/solareclipseworkbench/gui.py
+++ b/src/solareclipseworkbench/gui.py
@@ -1227,7 +1227,7 @@ class SimulatorPopup(QWidget, Observable):
         layout = QVBoxLayout()
 
         hbox1.addWidget(self.offset_minutes)
-        hbox1.addWidget(QLabel("minutes"))
+        hbox1.addWidget(QLabel("minute(s)"))
         hbox1.addWidget(self.before_after_combobox)
         hbox1.addWidget(self.reference_moment_combobox)
 

--- a/src/solareclipseworkbench/utils.py
+++ b/src/solareclipseworkbench/utils.py
@@ -115,11 +115,11 @@ def schedule_command(scheduler: BackgroundScheduler, reference_moments, cmd_str:
     args = cmd_str_split[4:-1]
 
     if func_name == "take_picture":
-        settings = CameraSettings(args[1].strip(), float(args[2].strip()), int(args[3].strip()))
+        settings = CameraSettings(args[0].strip(), args[1].strip(), float(args[2].strip()), int(args[3].strip()))
         new_args = [cameras[args[0].strip()], settings]
         args = new_args
     elif func_name == "take_burst":
-        settings = CameraSettings(args[1].strip(), float(args[2].strip()), int(args[3].strip()))
+        settings = CameraSettings(args[0].strip(), args[1].strip(), float(args[2].strip()), int(args[3].strip()))
         new_args = [cameras[args[0].strip()], settings, float(args[4].strip())]
         args = new_args
     elif func_name == "sync_cameras":


### PR DESCRIPTION
# Summary

## Start of simulation

It is now possible - when starting the UI in simulation mode (with `--sim` or `--simulator`) - to define the starting time of the simulation.  This is expressed in minutes before/after a reference moment of the eclipse (C1, C2, MAX, C3, C4, sunrise, or sunset).

Pressing the simulation button in the toolbar of the UI, will make the following pop-up window appear:

<img width="336" alt="Screenshot 2024-02-26 at 20 34 10" src="https://github.com/AstroWimSara/SolarEclipseWorkbench/assets/10076088/33a15e79-75e9-44b5-898a-2d5eccc6d5c7">

When pressing the OK button and then loading the configuration file, the execution times of the commands are computed as defined in the pop-up window.

## Scheduled jobs

Improved display of scheduled job.  For the scheduled jobs that occur áfter the start of the simulation (all others are hidden), the following is displayed:
- Time at which the job is scheduled;
- Function call (incl. arguments);
- Description, as per configuration file.

# Test result

Loaded the `voice_prompt.txt` configuration file after specifying the start of the simulation as 1 minute before C1.  The voice prompts were executed at the expected times.