### PR TITLE
Show duration for total eclipses

### DIFF
--- a/src/solareclipseworkbench/gui.py
+++ b/src/solareclipseworkbench/gui.py
@@ -614,7 +614,8 @@ class SolarEclipseView(QMainWindow, Observable):
         elif eclipse_type == "No eclipse":
             self.eclipse_type.setText(eclipse_type)
         else:
-            self.eclipse_type.setText(eclipse_type + " eclipse")
+            minutes, seconds = divmod(reference_moments["duration"].seconds, 60)
+            self.eclipse_type.setText(f"{eclipse_type} eclipse ({minutes}:{seconds:02})")
 
         suffix = ""
 


### PR DESCRIPTION
# Summary

For total eclipses, the duration of the eclipse is shown next to the eclipse type.

# Test results

See screenshot for test in simulator mode.

<img width="459" alt="Screenshot 2024-03-03 at 21 35 48" src="https://github.com/AstroWimSara/SolarEclipseWorkbench/assets/10076088/20c9ced9-1e34-442f-a288-1b65e058383c">
