### PR TITLE
Saving & loading settings

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7,7 +7,7 @@
   
 ### GUI
 
-- [ ] Save settings and reopen same settings again
+- [x] Save settings and reopen same settings again
 - [ ] Calculate list of solar eclipse (don't use a fixed list)
 - [ ] Log all actions
 

--- a/src/solareclipseworkbench/gui.py
+++ b/src/solareclipseworkbench/gui.py
@@ -334,6 +334,44 @@ class SolarEclipseView(QMainWindow, Observable):
 
         self.init_ui()
 
+    def closeEvent(self, event):
+        """ Save the settings when the UI is closed. """
+
+        self.save_settings()
+
+    def save_settings(self):
+        """ Save the settings.
+
+        The settings that are saved are:
+        
+            - Longitude [degrees];
+            - Latitude [degrees];
+            - Altitude [m];
+            - Eclipse date;
+            - Date format;
+            - Time format.
+        """
+
+        # Location
+
+        longitude = self.longitude_label.text()
+        latitude = self.latitude_label.text()
+        altitude = self.altitude_label.text()
+
+        if longitude and latitude and altitude:
+            self.settings.setValue("longitude", float(longitude))
+            self.settings.setValue("latitude", float(latitude))
+            self.settings.setValue("altitude", float(altitude))
+
+        # Eclipse date
+
+        self.settings.setValue("eclipse_date", self.eclipse_date.text())
+
+        # Date & time format
+
+        self.settings.setValue("date_format", self.date_format)
+        self.settings.setValue("time_format", self.time_format)
+
     def init_ui(self):
         """ Add all components to the UI. """
 


### PR DESCRIPTION
# Summary

When the UI window is closed, the data that are filled out in the UI are saved in a settings file (`SolarEclipseWorkbench.ini`).  These data are:
- The position of the observing location (longitude, latitude, altitude);
- The eclipse date;
- The date format from the settings;
- The time format from the settings.

The next time the UI is opened, that settings file is read and the values are loaded into the view and the model, and the date and time formatting are applied to the displayed data.

In case command line arguments are used to start the UI, these take precedence over the values from the settings file.

When the UI is closed, the current settings are saved in the existing settings file
→ TBD whether we want this, rather than including a "Save settings" button in the toolbar of the UI.

# Test results

- The first time the UI is opened and closed, a `SolarEclipseWorkbench.ini` file is created, with the expected numbers.  The next time the UI is opened, without command line arguments, these numbers are filled out, and the date and time format are applied to the displayed data.
- When command line arguments are used to open the UI, it's those numbers that are displayed, rather than the ones from the settings file.