### PR TITLE
Fix cancel button of `SettingsPopup`

### DIFF
--- a/src/solareclipseworkbench/gui.py
+++ b/src/solareclipseworkbench/gui.py
@@ -1327,7 +1327,7 @@ class SettingsPopup(QWidget, Observable):
         ok_button = QPushButton("OK")
         ok_button.clicked.connect(self.accept_settings)
         cancel_button = QPushButton("Cancel")
-        ok_button.clicked.connect(self.cancel_settings)
+        cancel_button.clicked.connect(self.cancel_settings)
         layout.addWidget(ok_button, 2, 0)
         layout.addWidget(cancel_button, 2, 1)
 


### PR DESCRIPTION
# Summary

Pushing the cancel button of the `SettingsPopup` would not close the pop-up window.  This is fixed now.

# Related issues

#53 

# Test results

When the cancel button in the datetime pop-up window is clicked, the pop-up window is closed.