### PR TITLE
Fixes Nikon burst/reset TypeError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [1.7.2] - 2026-04-05
+
+### Fixed
+- **Nikon burst/reset TypeError**: Prevent a crash in `take_burst` when resetting Nikon `stillcapturemode` and `burstnumber` by using numeric widget values (`0` / `1`) instead of strings. Fixes a `TypeError` from the gphoto2 binding that could cause subsequent commands to be repeated after a burst.
+
 ## [1.7.1] - 2026-03-30
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "solareclipseworkbench"
-version = "1.7.1"
+version = "1.7.2"
 description = "Tools to photograph solar eclipses"
 readme = "README.md"
 license = { text = "GPL-3.0-or-later" }

--- a/src/solareclipseworkbench/camera.py
+++ b/src/solareclipseworkbench/camera.py
@@ -676,7 +676,7 @@ def take_picture(camera: Camera, camera_settings: CameraSettings) -> None:
         except gphoto2.GPhoto2Error:
             try:
                 capture_mode_widget = gp.check_result(gp.gp_widget_get_child_by_name(config, 'stillcapturemode'))
-                gp.gp_widget_set_value(capture_mode_widget, '0')  # 0 = Single Frame
+                gp.gp_widget_set_value(capture_mode_widget, 0)  # 0 = Single Frame
                 _set_gp_config(camera, config, context)
                 logging.debug('Ensured Nikon stillcapturemode is Single Frame (0) before take_picture')
             except gphoto2.GPhoto2Error as e:
@@ -987,14 +987,14 @@ def take_burst(camera: Camera, camera_settings: CameraSettings, duration: float)
         except gphoto2.GPhoto2Error:
             try:
                 capture_mode_reset = gp.check_result(gp.gp_widget_get_child_by_name(config_reset, 'stillcapturemode'))
-                gp.gp_widget_set_value(capture_mode_reset, '0')  # 0 = Single Frame
+                gp.gp_widget_set_value(capture_mode_reset, 0)  # 0 = Single Frame
                 _set_gp_config(camera, config_reset, context)
                 logging.debug('Reset Nikon stillcapturemode to Single Frame (0) after burst')
             except gphoto2.GPhoto2Error as e:
                 logging.warning('Could not reset Nikon capture mode to single after burst: %s', e)
         try:
             burst_number_reset = gp.check_result(gp.gp_widget_get_child_by_name(config_reset, 'burstnumber'))
-            gp.gp_widget_set_value(burst_number_reset, '1')
+            gp.gp_widget_set_value(burst_number_reset, 1)
             _set_gp_config(camera, config_reset, context)
             logging.debug('Reset Nikon burstnumber to 1 after burst')
         except gphoto2.GPhoto2Error as e:

--- a/uv.lock
+++ b/uv.lock
@@ -1446,7 +1446,7 @@ wheels = [
 
 [[package]]
 name = "solareclipseworkbench"
-version = "1.7.1"
+version = "1.7.2"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
Passes numeric widget values (0/1) to the gphoto2 binding when resetting Nikon capture mode and burst number, preventing a TypeError that could crash burst handling and cause subsequent commands to be repeated.

Bumps package version to 1.7.2 and documents the fix in the changelog.