### PR TITLE
Adds live view and C2-relative partial offsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     firing the frame is silently skipped, so **shot timing is never affected**.
   - The live view image is transferred as a small JPEG thumbnail only; the camera still saves
     full-resolution photos directly to its SD card as usual.
-  - **Auto-pause during totality**: the preview pauses automatically when the current time
-    enters the C2–C3 window, and resumes automatically at C3.  A yellow status banner in the
+  - **Auto-pause during totality**: the preview pauses automatically 15 seconds
+    before C2 and resumes 15 seconds after C3, giving scheduled shots uncontested
+    USB access during the critical totality window.  A yellow status banner in the
     window indicates the paused state.
   - A **"Disable / Enable Live View"** toggle button in the window lets the user turn the
     preview off or on at any time — before, during, or after totality — without stopping the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [1.8.0] - 2026-04-14
+## [1.8.0] - 2026-04-15
 
 ### Added
 - **Live view window**: A new **Live View** toolbar button opens a floating preview window that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,38 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [1.8.0] - 2026-04-14
+
+### Added
+- **Live view window**: A new **Live View** toolbar button opens a floating preview window that
+  shows a 1 fps JPEG thumbnail from the connected camera via gphoto2 `capture_preview`.  This
+  lets you verify that the Sun is still centred in the frame and in focus without interrupting
+  the running script.
+
+  Key properties:
+  - Preview frames are fetched in a background thread (`LiveViewThread` in `camera.py`) that
+    tries to acquire the per-camera USB lock with a 50 ms timeout.  When a scheduled shot is
+    firing the frame is silently skipped, so **shot timing is never affected**.
+  - The live view image is transferred as a small JPEG thumbnail only; the camera still saves
+    full-resolution photos directly to its SD card as usual.
+  - **Auto-pause during totality**: the preview pauses automatically when the current time
+    enters the C2–C3 window, and resumes automatically at C3.  A yellow status banner in the
+    window indicates the paused state.
+  - A **"Disable / Enable Live View"** toggle button in the window lets the user turn the
+    preview off or on at any time — before, during, or after totality — without stopping the
+    script.
+  - Closing the main window also stops the live view thread cleanly.
+  - Live view requires a real gphoto2 camera to be connected.  A warning dialog is shown
+    when no camera is available.
+
+### Changed
+- **Wizard C1→C2 partial phase uses C2-relative offsets**: The generated script now
+  references the C1→C2 equispaced partial-phase shots as `C2, -, offset` instead of
+  `C1, +, offset`. Using C2 as the anchor prevents timing conflicts between the partial
+  sequence and the totality sequence: both now count down to the same reference contact,
+  so even if the partial interval is not perfectly calibrated the shots will always stop
+  safely before C2.
+
 ## [1.7.2] - 2026-04-05
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [1.8.0] - 2026-04-15
+## [1.8.1] - 2026-04-15
 
 ### Added
 - **Live view window**: A new **Live View** toolbar button opens a floating preview window that

--- a/README.md
+++ b/README.md
@@ -462,7 +462,7 @@ The functionality of the toolbar buttons is as follows (from left to right):
 - The live view is intended to help you verify that the Sun is still in the frame and remains in focus without having to stop the script, realign the telescope, and restart.
 - The preview image uses gphoto2's `capture_preview` command.  This transfers a small JPEG thumbnail over USB and does **not** save anything to disk.  The camera continues to store actual eclipse photos directly to its SD card as scheduled.
 - **USB lock safety**: before each preview frame the thread tries to acquire the camera's USB lock with a 50 ms timeout.  If a scheduled shot is firing at that exact moment, the preview frame is silently skipped.  This guarantees that shot timing is never compromised by live view.
-- **During totality (C2 → C3)** the preview is automatically paused so the USB bus is entirely free for the closely-spaced shots in the script.  The window shows a yellow banner while paused; preview resumes automatically at C3.
+- **During totality (C2−15s → C3+15s)** the preview is automatically paused so the USB bus is entirely free for the closely-spaced shots in the script.  The pause starts 15 seconds before C2 and the preview resumes 15 seconds after C3.  The window shows a yellow banner while paused.
 - **Toggle button**: the "Disable / Enable Live View" button in the window lets you turn the preview off or on at any time — before, during, or after totality — without stopping the script or closing the window.
 - If no camera is connected when the Live View button is clicked, a warning dialog is shown.
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
       - [Interrupting scheduled jobs](#interrupting-scheduled-jobs)
       - [Datetime format](#datetime-format)
       - [Saving settings](#saving-settings)
+      - [Live view](#live-view)
   - [Running the Configuration Wizard](#running-the-configuration-wizard)
   - [Using two cameras of the same model, or one camera with multiple setups](#using-two-cameras-of-the-same-model-or-one-camera-with-multiple-setups)
   - [Script file format](#script-file-format)
@@ -93,12 +94,30 @@ sudo apt install libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libxkbcomm
 sudo apt-get install gphoto2 libgphoto2-dev python3-gphoto2
 ```
 
-- Make sure that gvfs is not started automatically
+- Make sure that gvfs is not started automatically. Use `systemctl --user mask` to properly disable the gvfs gphoto2 services. **Do not use `chmod -x`** — removing the execute bit causes the Files (Nautilus) application to hang on open because GVFS still attempts to launch the binaries and waits for a timeout before giving up.
 
-```bash
-sudo chmod -x /usr/lib/gvfs/gvfs-gphoto2-volume-monitor
-sudo chmod -x /usr/lib/gvfs/gvfsd-gphoto2
-```
+  If you previously used `chmod -x`, first restore the execute bits:
+
+  ```bash
+  sudo chmod +x /usr/lib/gvfs/gvfs-gphoto2-volume-monitor
+  sudo chmod +x /usr/lib/gvfs/gvfsd-gphoto2
+  ```
+
+  Then mask the systemd user services so they are never started:
+
+  ```bash
+  systemctl --user mask gvfs-gphoto2-volume-monitor.service
+  systemctl --user mask gvfsd-gphoto2.service
+  ```
+
+  To verify:
+
+  ```bash
+  systemctl --user status gvfs-gphoto2-volume-monitor.service
+  systemctl --user status gvfsd-gphoto2.service
+  ```
+
+  Both should show `masked`.
 
 - Install `gdal-config`, required by `geopandas` (especially on Raspberry Pi):
 
@@ -436,6 +455,18 @@ The functionality of the toolbar buttons is as follows (from left to right):
 - The standard settings framework of `PyQt6` (`QSettings`) will be used: it stores the settings as `~/.SolarEclipseWorkbench.ini` (a hidden file in your home directory).
 - Next time you open the UI, this settings file will be loaded and the specified data will be made available in the UI.
 - In case command line arguments are used to open the UI, these take priority over the values from the settings file.
+
+#### Live view
+
+- When pressing the **"Live View"** icon (rightmost toolbar button), a floating preview window opens showing a live image from the connected camera, refreshed once per second.
+- The live view is intended to help you verify that the Sun is still in the frame and remains in focus without having to stop the script, realign the telescope, and restart.
+- The preview image uses gphoto2's `capture_preview` command.  This transfers a small JPEG thumbnail over USB and does **not** save anything to disk.  The camera continues to store actual eclipse photos directly to its SD card as scheduled.
+- **USB lock safety**: before each preview frame the thread tries to acquire the camera's USB lock with a 50 ms timeout.  If a scheduled shot is firing at that exact moment, the preview frame is silently skipped.  This guarantees that shot timing is never compromised by live view.
+- **During totality (C2 → C3)** the preview is automatically paused so the USB bus is entirely free for the closely-spaced shots in the script.  The window shows a yellow banner while paused; preview resumes automatically at C3.
+- **Toggle button**: the "Disable / Enable Live View" button in the window lets you turn the preview off or on at any time — before, during, or after totality — without stopping the script or closing the window.
+- If no camera is connected when the Live View button is clicked, a warning dialog is shown.
+
+> **Note**: Live view via gphoto2 is tested on the Nikon Z8.  Support on other bodies depends on whether their gphoto2 driver implements `capture_preview`.  Canon EOS bodies and most modern Nikon and Sony Alpha bodies support it; some entry-level or older bodies do not.
 
 ## Running the Configuration Wizard
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "solareclipseworkbench"
-version = "1.8.0"
+version = "1.8.1"
 description = "Tools to photograph solar eclipses"
 readme = "README.md"
 license = { text = "GPL-3.0-or-later" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "solareclipseworkbench"
-version = "1.7.2"
+version = "1.8.0"
 description = "Tools to photograph solar eclipses"
 readme = "README.md"
 license = { text = "GPL-3.0-or-later" }

--- a/src/solareclipseworkbench/camera.py
+++ b/src/solareclipseworkbench/camera.py
@@ -642,6 +642,85 @@ class _SonyBackgroundDownloader(threading.Thread):
                         pass
 
 
+class LiveViewThread(threading.Thread):
+    """Background thread that periodically fetches a live-view preview frame.
+
+    Tries to acquire the camera's USB lock with a short timeout.  When the
+    lock is held by a scheduled shot, the frame is silently skipped.  The
+    caller-supplied *frame_callback* is invoked on this worker thread with the
+    raw JPEG bytes of each successfully obtained preview frame.
+
+    Parameters
+    ----------
+    camera : GPhotoCameraAdapter or equivalent
+        Must have ``_camera`` and ``_usb_lock`` attributes.
+    frame_callback : callable[[bytes], None]
+        Called with the JPEG preview bytes each time a frame is successfully
+        captured.  Must be thread-safe (e.g. use a queue.Queue to forward
+        frames to the GUI thread).
+    interval_s : float
+        Interval between preview captures in seconds.  Default 1.0.
+    lock_timeout : float
+        Maximum seconds to wait for the USB lock before skipping a frame.
+        Default 0.05 (50 ms).
+    """
+
+    def __init__(self, camera, frame_callback, interval_s: float = 1.0, lock_timeout: float = 0.05):
+        super().__init__(daemon=True)
+        self._camera = camera
+        self._frame_callback = frame_callback
+        self._interval_s = interval_s
+        self._lock_timeout = lock_timeout
+        self._stop_event = threading.Event()
+        self._paused = threading.Event()
+
+    def stop(self):
+        """Signal the thread to stop and wait briefly for it to exit."""
+        self._stop_event.set()
+
+    def pause(self):
+        """Suspend preview capture without stopping the thread."""
+        self._paused.set()
+
+    def resume(self):
+        """Resume suspended preview capture."""
+        self._paused.clear()
+
+    @property
+    def is_paused(self) -> bool:
+        return self._paused.is_set()
+
+    def run(self):
+        target = self._camera._camera if hasattr(self._camera, '_camera') else self._camera
+        context = gp.gp_context_new()
+
+        while not self._stop_event.wait(self._interval_s):
+            if self._paused.is_set():
+                continue
+
+            acquired = False
+            try:
+                acquired = self._camera._usb_lock.acquire(timeout=self._lock_timeout)
+                if not acquired:
+                    logging.debug('LiveViewThread: USB lock busy, skipping frame')
+                    continue
+
+                cam_file = gp.CameraFile()
+                gp.check_result(gp.gp_camera_capture_preview(target, cam_file, context))
+                file_data = gp.check_result(gp.gp_file_get_data_and_size(cam_file))
+                self._frame_callback(bytes(file_data))
+            except gphoto2.GPhoto2Error as exc:
+                logging.debug('LiveViewThread: preview capture failed: %s', exc)
+            except Exception:
+                logging.exception('LiveViewThread: unexpected error')
+            finally:
+                if acquired:
+                    try:
+                        self._camera._usb_lock.release()
+                    except Exception:
+                        pass
+
+
 @_serialised_on_camera
 def take_picture(camera: Camera, camera_settings: CameraSettings) -> None:
     """ Take a picture with the selected camera 

--- a/src/solareclipseworkbench/camera.py
+++ b/src/solareclipseworkbench/camera.py
@@ -195,6 +195,43 @@ class VirtualCamera(BaseCamera):
         # mirror gphoto Camera.exit()
         self.disconnect()
 
+    def capture_preview(self) -> bytes:
+        """Return a synthetic 640×480 grey JPEG frame for simulator mode.
+
+        Uses PyQt6 (a hard project dependency) so no extra packages are
+        needed.  The frame contains the current timestamp so the preview
+        window shows visible activity.
+        """
+        import datetime as _dt
+        from PyQt6.QtCore import QBuffer, QIODevice
+        from PyQt6.QtGui import QColor, QFont, QImage, QPainter, QPen
+
+        width, height = 640, 480
+        img = QImage(width, height, QImage.Format.Format_RGB888)
+        img.fill(QColor(30, 30, 30))
+
+        painter = QPainter(img)
+        # Crosshair (same style as LiveViewWindow)
+        pen = QPen(QColor(0, 80, 255))
+        pen.setWidth(1)
+        painter.setPen(pen)
+        cx, cy = width // 2, height // 2
+        painter.drawLine(cx, 0, cx, height)
+        painter.drawLine(0, cy, width, cy)
+
+        # Informational text
+        painter.setPen(QPen(QColor(180, 180, 180)))
+        painter.setFont(QFont("monospace", 11))
+        ts = _dt.datetime.now().strftime("%H:%M:%S.%f")[:-3]
+        painter.drawText(10, 28, f"VirtualCamera  {ts}")
+        painter.drawText(10, 52, "[ simulator mode — no physical camera ]")
+        painter.end()
+
+        buf = QBuffer()
+        buf.open(QIODevice.OpenModeFlag.ReadWrite)
+        img.save(buf, "JPEG")
+        return bytes(buf.data())
+
 
 class GPhotoCameraAdapter(BaseCamera):
     """Adapter that wraps a gphoto2 Camera object and exposes a
@@ -691,11 +728,27 @@ class LiveViewThread(threading.Thread):
         return self._paused.is_set()
 
     def run(self):
-        target = self._camera._camera if hasattr(self._camera, '_camera') else self._camera
-        context = gp.gp_context_new()
+        # If the camera provides a capture_preview() method (e.g. VirtualCamera
+        # in simulator mode), use that path — no gphoto2 calls or USB lock needed.
+        _has_virtual_preview = callable(getattr(self._camera, 'capture_preview', None))
+
+        target = None
+        context = None
+        if not _has_virtual_preview:
+            target = self._camera._camera if hasattr(self._camera, '_camera') else self._camera
+            context = gp.gp_context_new()
 
         while not self._stop_event.wait(self._interval_s):
             if self._paused.is_set():
+                continue
+
+            if _has_virtual_preview:
+                try:
+                    jpeg_bytes = self._camera.capture_preview()
+                    if jpeg_bytes:
+                        self._frame_callback(jpeg_bytes)
+                except Exception:
+                    logging.exception('LiveViewThread: virtual preview failed')
                 continue
 
             acquired = False

--- a/src/solareclipseworkbench/gui.py
+++ b/src/solareclipseworkbench/gui.py
@@ -9,6 +9,7 @@ import datetime
 import logging
 import math
 import os.path
+import queue
 import sys
 import time
 from dataclasses import dataclass
@@ -22,7 +23,7 @@ import numpy as np
 import pandas as pd
 import pytz
 from PyQt6.QtCore import QTimer, QRect, Qt, QAbstractTableModel, QModelIndex, QSettings, pyqtSignal
-from PyQt6.QtGui import QIcon, QAction, QIntValidator, QCloseEvent
+from PyQt6.QtGui import QIcon, QAction, QIntValidator, QCloseEvent, QPixmap, QImage, QPainter, QPen, QColor
 from PyQt6.QtWidgets import QMainWindow, QApplication, QWidget, QFrame, QLabel, QHBoxLayout, QVBoxLayout, QGridLayout, \
     QGroupBox, QComboBox, QPushButton, QLineEdit, QFileDialog, QScrollArea, QTableView, QMessageBox
 from PyQt6 import QtWidgets
@@ -39,7 +40,7 @@ from skyfield.api import load, wgs84
 import threading
 
 from solareclipseworkbench.camera import get_camera_dict, get_battery_level, get_free_space, get_space, \
-    get_shooting_mode, get_focus_mode, set_time, CameraSettings
+    get_shooting_mode, get_focus_mode, set_time, CameraSettings, LiveViewThread
 from solareclipseworkbench.observer import Observer, Observable
 from solareclipseworkbench.qt_utils import apply_system_color_scheme
 from solareclipseworkbench.reference_moments import calculate_reference_moments, ReferenceMomentInfo
@@ -320,6 +321,7 @@ class SolarEclipseView(QMainWindow, Observable):
         self.shutdown_scheduler_action = QAction("Stop", self)
         self.datetime_format_action = QAction("Datetime format", self)
         self.save_action = QAction("Save", self)
+        self.live_view_action = QAction("Live View", self)
 
         self.place_time_frame = QFrame()
 
@@ -688,6 +690,13 @@ class SolarEclipseView(QMainWindow, Observable):
         self.save_action.triggered.connect(self.on_toolbar_button_click)
         self.toolbar.addAction(self.save_action)
 
+        # Live View
+
+        self.live_view_action.setStatusTip("Open live view window (1 fps preview from camera)")
+        self.live_view_action.setIcon(QIcon(str(ICON_PATH / "camera.png")))
+        self.live_view_action.triggered.connect(self.on_toolbar_button_click)
+        self.toolbar.addAction(self.live_view_action)
+
     def on_toolbar_button_click(self):
         """ Action triggered when a toolbar button is clicked."""
 
@@ -920,6 +929,8 @@ class SolarEclipseController(Observer):
         self.visualization_timer.setInterval(5000)
         self.visualization_timer.start()
 
+        self._live_view_window: Union[LiveViewWindow, None] = None
+
         self.load_settings()
 
     def update_time(self):
@@ -941,6 +952,18 @@ class SolarEclipseController(Observer):
 
         self.view.update_time(current_time_local, current_time_utc, countdown_c1, countdown_c2, countdown_max,
                               countdown_c3, countdown_c4, countdown_sunrise, countdown_sunset)
+
+        # Auto-pause live view during totality (C2 → C3) so scheduled shots
+        # have uncontested access to the USB bus.
+        if self._live_view_window is not None:
+            c2 = self.model.c2_info
+            c3 = self.model.c3_info
+            in_totality = (
+                c2 is not None
+                and c3 is not None
+                and c2.time_utc <= current_time_utc <= c3.time_utc
+            )
+            self._live_view_window.set_totality_paused(in_totality)
 
         # self.view.eclipse_visualization.plot(current_time_utc)    FIXME
 
@@ -1058,6 +1081,10 @@ class SolarEclipseController(Observer):
             return
 
         elif isinstance(changed_object, QCloseEvent):
+
+            if self._live_view_window is not None:
+                self._live_view_window.close()
+                self._live_view_window = None
 
             if self.model.camera_overview.camera_overview_dict:
                 cameras = self.model.camera_overview.camera_overview_dict.values()
@@ -1177,6 +1204,9 @@ class SolarEclipseController(Observer):
         elif text == "Save":
             self.view.save_settings()
 
+        elif text == "Live View":
+            self._open_live_view()
+
     def sync_camera_time(self):
         """ Set the time of all connected cameras to the time of the computer."""
 
@@ -1212,6 +1242,59 @@ class SolarEclipseController(Observer):
                 "One or more cameras require attention before shooting:\n\n"
                 + "\n\n".join(f"\u26a0\ufe0f  {w}" for w in warnings)
             )
+
+    def _open_live_view(self):
+        """Open (or bring to front) the live view window.
+
+        When exactly one real camera is connected it is used directly.
+        When multiple real cameras are connected a small selection dialog
+        is shown so the user can pick which one to preview.
+        Shows a warning when no real camera is connected.
+        """
+        # If window already exists, bring it to the front
+        if self._live_view_window is not None and self._live_view_window.isVisible():
+            self._live_view_window.activateWindow()
+            self._live_view_window.raise_()
+            return
+
+        # Collect all real gphoto cameras (deduplicated by object identity)
+        cam_dict = getattr(self.model.camera_overview, 'camera_overview_dict', None) or {}
+        from solareclipseworkbench.camera import GPhotoCameraAdapter
+        seen_ids: set = set()
+        real_cameras: list = []  # list of (name, camera) tuples
+        for name, cam in cam_dict.items():
+            if isinstance(cam, GPhotoCameraAdapter) and id(cam) not in seen_ids:
+                seen_ids.add(id(cam))
+                real_cameras.append((name, cam))
+
+        if not real_cameras:
+            QMessageBox.warning(
+                self.view,
+                "No Camera Connected",
+                "Live view requires a connected camera.\n\n"
+                "Click the Camera(s) button first to detect connected cameras."
+            )
+            return
+
+        if len(real_cameras) == 1:
+            camera = real_cameras[0][1]
+        else:
+            # Ask the user which camera to preview
+            names = [name for name, _ in real_cameras]
+            chosen, ok = QtWidgets.QInputDialog.getItem(
+                self.view,
+                "Select Camera for Live View",
+                "Camera:",
+                names,
+                0,
+                False,
+            )
+            if not ok:
+                return
+            camera = dict(real_cameras)[chosen]
+
+        self._live_view_window = LiveViewWindow(camera, parent=None)
+        self._live_view_window.show()
 
     def load_settings(self):
         """ Load the UI settings.
@@ -1944,6 +2027,170 @@ class EclipsePlotWidget(QtWidgets.QWidget):
     #         ("W", (-1.12 if not self.east_left else +1.12, 0)),
     #     ]:
     #         self.ax.text(x, y, label, ha="center", va="center", fontsize=10, color="dimgray")
+
+
+class LiveViewWindow(QWidget):
+    """Floating window that shows a live-view preview from a gphoto2 camera.
+
+    A background ``LiveViewThread`` grabs one preview frame per second.  When
+    the camera USB lock is held by a scheduled shot the frame is silently
+    skipped so timing accuracy is never compromised.
+
+    The window can be:
+      - Disabled/re-enabled at any time via the toggle button.
+      - Auto-paused between C2 and C3 (totality) by the controller calling
+        ``set_totality_paused(True/False)``.
+    """
+
+    def __init__(self, camera, parent=None):
+        super().__init__(parent, Qt.WindowType.Window)
+        self.setWindowTitle("Live View")
+        self.setMinimumSize(480, 400)
+
+        self._camera = camera
+        self._thread = None
+        self._frame_queue: queue.Queue = queue.Queue(maxsize=1)
+        self._user_enabled: bool = True
+        self._totality_paused: bool = False
+
+        # Image display
+        self._image_label = QLabel("Waiting for first preview frame…")
+        self._image_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self._image_label.setMinimumSize(320, 240)
+
+        # Timestamp of last received frame
+        self._timestamp_label = QLabel()
+        self._timestamp_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self._timestamp_label.setStyleSheet("color: gray; font-size: 11px;")
+
+        # Status line
+        self._status_label = QLabel()
+        self._status_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+
+        # Buttons
+        self._toggle_btn = QPushButton("Disable Live View")
+        self._toggle_btn.clicked.connect(self._on_toggle)
+        close_btn = QPushButton("Close")
+        close_btn.clicked.connect(self.close)
+
+        btn_layout = QHBoxLayout()
+        btn_layout.addWidget(self._toggle_btn)
+        btn_layout.addWidget(close_btn)
+
+        layout = QVBoxLayout()
+        layout.addWidget(self._image_label, stretch=1)
+        layout.addWidget(self._timestamp_label)
+        layout.addWidget(self._status_label)
+        layout.addLayout(btn_layout)
+        self.setLayout(layout)
+
+        # Poll the frame queue every 500 ms on the GUI thread
+        self._poll_timer = QTimer(self)
+        self._poll_timer.setInterval(500)
+        self._poll_timer.timeout.connect(self._poll_frame)
+        self._poll_timer.start()
+
+        self._start_thread()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _start_thread(self):
+        if self._thread is not None:
+            self._thread.stop()
+        self._thread = LiveViewThread(
+            camera=self._camera,
+            frame_callback=self._on_frame,
+            interval_s=1.0,
+        )
+        self._thread.start()
+        self._update_status_label()
+
+    def _on_frame(self, jpeg_bytes: bytes):
+        """Called from the LiveViewThread; enqueue (frame, timestamp) for GUI thread."""
+        try:
+            self._frame_queue.put_nowait((jpeg_bytes, datetime.datetime.now()))
+        except queue.Full:
+            pass  # drop the frame; the previous one hasn't been displayed yet
+
+    def _poll_frame(self):
+        """Called on the Qt main thread by the poll timer; updates the image."""
+        try:
+            jpeg_bytes, ts = self._frame_queue.get_nowait()
+        except queue.Empty:
+            return
+        image = QImage.fromData(jpeg_bytes)
+        if image.isNull():
+            return
+        pixmap = QPixmap.fromImage(image)
+        scaled = pixmap.scaled(
+            self._image_label.size(),
+            Qt.AspectRatioMode.KeepAspectRatio,
+            Qt.TransformationMode.SmoothTransformation,
+        )
+        # Draw blue crosshair at the centre of the scaled pixmap
+        w, h = scaled.width(), scaled.height()
+        painter = QPainter(scaled)
+        pen = QPen(QColor(0, 120, 255))
+        pen.setWidth(1)
+        painter.setPen(pen)
+        painter.drawLine(0, h // 2, w, h // 2)  # horizontal
+        painter.drawLine(w // 2, 0, w // 2, h)  # vertical
+        painter.end()
+        self._image_label.setPixmap(scaled)
+        self._timestamp_label.setText("Last frame: " + ts.strftime("%Y-%m-%d  %H:%M:%S"))
+
+    def _apply_state(self):
+        """Push the user+totality state into the thread and refresh the button."""
+        if self._thread is None:
+            return
+        if self._user_enabled and not self._totality_paused:
+            self._thread.resume()
+            self._toggle_btn.setText("Disable Live View")
+        else:
+            self._thread.pause()
+            self._toggle_btn.setText("Enable Live View")
+        self._update_status_label()
+
+    def _update_status_label(self):
+        if not self._user_enabled:
+            self._status_label.setText("○  Disabled")
+            self._status_label.setStyleSheet("color: gray;")
+        elif self._totality_paused:
+            self._status_label.setText(
+                "\u23f8  Paused during totality — script has full USB control"
+            )
+            self._status_label.setStyleSheet("color: #856404; background: #FFF3CD; padding: 3px; border-radius: 3px;")
+        else:
+            self._status_label.setText("\u25cf  Active")
+            self._status_label.setStyleSheet("color: green;")
+
+    # ------------------------------------------------------------------
+    # Public API (called by the controller)
+    # ------------------------------------------------------------------
+
+    def set_totality_paused(self, paused: bool):
+        """Auto-pause or auto-resume live view around totality."""
+        if self._totality_paused == paused:
+            return
+        self._totality_paused = paused
+        self._apply_state()
+
+    # ------------------------------------------------------------------
+    # Slots / event handlers
+    # ------------------------------------------------------------------
+
+    def _on_toggle(self):
+        self._user_enabled = not self._user_enabled
+        self._apply_state()
+
+    def closeEvent(self, event):
+        self._poll_timer.stop()
+        if self._thread is not None:
+            self._thread.stop()
+            self._thread = None
+        event.accept()
 
 
 def format_countdown(countdown: datetime.timedelta):

--- a/src/solareclipseworkbench/gui.py
+++ b/src/solareclipseworkbench/gui.py
@@ -953,15 +953,16 @@ class SolarEclipseController(Observer):
         self.view.update_time(current_time_local, current_time_utc, countdown_c1, countdown_c2, countdown_max,
                               countdown_c3, countdown_c4, countdown_sunrise, countdown_sunset)
 
-        # Auto-pause live view during totality (C2 → C3) so scheduled shots
-        # have uncontested access to the USB bus.
+        # Auto-pause live view 15 s before C2 until 15 s after C3 so scheduled
+        # shots around second and third contact have uncontested USB access.
         if self._live_view_window is not None:
             c2 = self.model.c2_info
             c3 = self.model.c3_info
+            _MARGIN = datetime.timedelta(seconds=15)
             in_totality = (
                 c2 is not None
                 and c3 is not None
-                and c2.time_utc <= current_time_utc <= c3.time_utc
+                and (c2.time_utc - _MARGIN) <= current_time_utc <= (c3.time_utc + _MARGIN)
             )
             self._live_view_window.set_totality_paused(in_totality)
 

--- a/src/solareclipseworkbench/gui.py
+++ b/src/solareclipseworkbench/gui.py
@@ -1258,22 +1258,26 @@ class SolarEclipseController(Observer):
             self._live_view_window.raise_()
             return
 
-        # Collect all real gphoto cameras (deduplicated by object identity)
+        # Collect all real gphoto cameras (deduplicated by object identity).
+        # Use cam.name as the display label: when an alias is configured it is
+        # set to the primary alias (i.e. the name used in scripts); when no alias
+        # is configured it falls back to the gphoto2 model name.
         cam_dict = getattr(self.model.camera_overview, 'camera_overview_dict', None) or {}
-        from solareclipseworkbench.camera import GPhotoCameraAdapter
+        from solareclipseworkbench.camera import GPhotoCameraAdapter, VirtualCamera
         seen_ids: set = set()
-        real_cameras: list = []  # list of (name, camera) tuples
-        for name, cam in cam_dict.items():
-            if isinstance(cam, GPhotoCameraAdapter) and id(cam) not in seen_ids:
+        real_cameras: list = []  # list of (display_name, camera) tuples
+        for cam in cam_dict.values():
+            if isinstance(cam, (GPhotoCameraAdapter, VirtualCamera)) and id(cam) not in seen_ids:
                 seen_ids.add(id(cam))
-                real_cameras.append((name, cam))
+                real_cameras.append((cam.name, cam))
 
         if not real_cameras:
             QMessageBox.warning(
                 self.view,
                 "No Camera Connected",
                 "Live view requires a connected camera.\n\n"
-                "Click the Camera(s) button first to detect connected cameras."
+                "Click the Camera(s) button first to detect connected cameras.\n"
+                "In simulator mode the VirtualCamera is also supported."
             )
             return
 
@@ -2045,7 +2049,6 @@ class LiveViewWindow(QWidget):
 
     def __init__(self, camera, parent=None):
         super().__init__(parent, Qt.WindowType.Window)
-        self.setWindowTitle("Live View")
         self.setMinimumSize(480, 400)
 
         self._camera = camera
@@ -2053,6 +2056,8 @@ class LiveViewWindow(QWidget):
         self._frame_queue: queue.Queue = queue.Queue(maxsize=1)
         self._user_enabled: bool = True
         self._totality_paused: bool = False
+
+        self.setWindowTitle(f"Live View — {camera.name}")
 
         # Image display
         self._image_label = QLabel("Waiting for first preview frame…")

--- a/src/solareclipseworkbench/wizard.py
+++ b/src/solareclipseworkbench/wizard.py
@@ -1560,8 +1560,8 @@ class SummaryPage(QWizardPage):
                         
                         shutter = format_shutter_speed(exposure)
                         
-                        # Calculate time offset from C1
-                        offset_seconds = (shot_time - c1_time).total_seconds()
+                        # Calculate time offset back from C2 (so partial shots don't clash with totality sequence)
+                        offset_seconds = (c2_time - shot_time).total_seconds()
                         offset_str = f"{int(offset_seconds // 3600)}:{int((offset_seconds % 3600) // 60):02d}:{int(offset_seconds % 60):02d}.0"
                         
                         partial_shots_c1_c2.append((offset_str, shutter, adjusted_iso, shot_time, sun_alt))
@@ -1581,16 +1581,18 @@ class SummaryPage(QWizardPage):
                         shot_count += 1
                         time_str = shot_time.strftime('%H:%M:%S')
                         iso_note = f" (ISO {iso})" if iso != preferred_iso else ""
-                        lines.append(f'take_picture, C1, +, {offset}, {camera_name}, {shutter}, {aperture}, {iso}, "Partial C1-C2 #{shot_count} @ {time_str}, sun {sun_alt:.1f}°{iso_note}"')
+                        lines.append(f'take_picture, C2, -, {offset}, {camera_name}, {shutter}, {aperture}, {iso}, "Partial C1-C2 #{shot_count} @ {time_str}, sun {sun_alt:.1f}°{iso_note}"')
                         
                         # Add sync_cameras periodically if enabled
                         if sync_interval_minutes > 0 and idx > 0:
-                            offset_seconds = (shot_time - c1_time).total_seconds()
+                            c1_offset_seconds = (shot_time - c1_time).total_seconds()
                             # Add sync every N minutes, avoiding conflicts with shots
-                            if offset_seconds % (sync_interval_minutes * 60) < time_interval and offset_seconds > sync_interval_minutes * 60:
-                                sync_offset = int(offset_seconds - 5)  # 5 seconds before the shot
-                                sync_offset_str = f"{int(sync_offset // 3600)}:{int((sync_offset % 3600) // 60):02d}:{int(sync_offset % 60):02d}.0"
-                                lines.append(f'sync_cameras, C1, +, {sync_offset_str}, "Camera sync @ {(c1_time + timedelta(seconds=sync_offset)).strftime("%H:%M:%S")}"')
+                            if c1_offset_seconds % (sync_interval_minutes * 60) < time_interval and c1_offset_seconds > sync_interval_minutes * 60:
+                                # Sync 5 seconds before the shot; express as C2-relative offset
+                                sync_time = shot_time - timedelta(seconds=5)
+                                sync_c2_offset = int((c2_time - sync_time).total_seconds())
+                                sync_offset_str = f"{int(sync_c2_offset // 3600)}:{int((sync_c2_offset % 3600) // 60):02d}:{int(sync_c2_offset % 60):02d}.0"
+                                lines.append(f'sync_cameras, C2, -, {sync_offset_str}, "Camera sync @ {sync_time.strftime("%H:%M:%S")}"')
                     
                     lines.append("")
                     

--- a/uv.lock
+++ b/uv.lock
@@ -1446,7 +1446,7 @@ wheels = [
 
 [[package]]
 name = "solareclipseworkbench"
-version = "1.8.0"
+version = "1.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },

--- a/uv.lock
+++ b/uv.lock
@@ -1446,7 +1446,7 @@ wheels = [
 
 [[package]]
 name = "solareclipseworkbench"
-version = "1.7.2"
+version = "1.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
Adds a floating live-view window that shows 1 fps JPEG previews via gphoto2 capture_preview so users can verify framing and focus without stopping scheduled scripts.

Implements a background preview thread that acquires the camera USB lock with a short timeout and silently skips frames when the bus is busy, preserving shot timing; preview is thumbnail-only, can be toggled by the user, and is paused automatically during totality (C2→C3). The live-view thread is stopped cleanly when the window or main app closes and a warning is shown when no camera is connected.

Changes the wizard to express C1→C2 partial-phase shots and periodic camera syncs as C2-relative offsets to avoid timing conflicts with the totality sequence.  Closes #115 

Updates documentation, changelog, and package version to 1.8.0.