### PR TITLE
Improves Sony handling, live preview, and aperture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,64 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [1.9.1] - 2026-04-20
+
+### Fixed
+- **Sony ILCE model detection in camera vendor classification**: SEW now treats
+  ILCE-prefixed model names (for example `ILCE-7M5`) as Sony everywhere vendor
+  detection is used. This ensures Sony-specific adapter selection and behavior
+  are applied even when gphoto2 reports the model without a literal `Sony`
+  prefix.
+
+- **Focus mode check accepts localized and firmware-specific values**: `get_focus_mode()` now
+  normalises values returned by gphoto2 that vary by camera firmware language or version.
+  Sony cameras with German firmware report `"Manuell"` instead of `"Manual"`, and some Sony
+  firmware versions report `"undefined"` when the lens/body switch is in the manual focus
+  position. Both are now treated as `"Manual"` so no spurious warning is shown.
+
+- **Sony downloader no longer starts on unknown/localized save-destination values**: the GUI
+  previously auto-started the Sony background downloader when the camera's PC-Remote **Save
+  Destination** could not be read via gphoto2. On localized firmware this could make SEW assume
+  the camera was in PC-only mode and start copying files to `~/Pictures/SolarEclipseWorkbench`,
+  stealing USB bandwidth from scheduled captures. The downloader is now started only when the
+  destination is confidently identified as PC-only; unknown values are treated conservatively as
+  no-download.
+
+- **Live preview crash on Nikon/Sony adapters**: Fixed a `TypeError` in `LiveViewWindow._poll_frame`
+  where `QImage.fromData(...)` could receive a `gphoto2.file.CameraFile` object instead of raw bytes.
+  `LiveViewThread` now uses the virtual-preview path only for `VirtualCamera` instances. Wrapped
+  gphoto2 cameras (including Nikon and Sony adapters) now always use the gphoto preview path that
+  extracts JPEG bytes correctly.
+
+- **Defensive live-preview frame handling in GUI**: `_poll_frame` now normalises `memoryview` and
+  `bytearray` frames to `bytes`, and safely logs/skips unsupported frame types instead of crashing.
+
+- **Sony burst timing and sequencing around C2/C3**: `take_burst()` for Sony no longer waits on
+  `_wait_for_capture_complete()` (Sony cameras do not emit `GP_EVENT_CAPTURE_COMPLETE`). The burst
+  loop now uses Sony-specific event draining (`_sony_drain_events` before each trigger and
+  `_drain_camera_events` after), matching the `take_picture()` path. This prevents long per-frame
+  waits that could stretch 30-frame bursts and cause nearby scheduled shots to be dropped or delayed.
+
+### Added
+- **Regression test for preview frame types**: Added `tests/test_live_view_preview_types.py` to
+  verify that non-virtual cameras exposing a delegated `capture_preview()` method still use the
+  gphoto preview path and deliver `bytes` to the GUI.
+
+- **Regression test for Sony save-destination downloader logic**: Added
+  `tests/test_sony_save_destination.py` to verify that the background downloader is enabled only
+  for clearly PC-only destinations, and not for mixed or unavailable values.
+
+- **Regression test for Sony burst event handling**: Added `tests/test_sony_burst.py` to verify
+  that Sony burst capture uses the non-blocking event-drain path and does not call
+  `_wait_for_capture_complete()`.
+
+- **Aperture read-back check**: After setting the aperture via gphoto2, SEW now reads
+  the value back from the camera and logs a `WARNING` if the camera reports a different
+  f-number than was requested. Sony Alpha bodies (and cameras with a fixed-aperture
+  lens) silently accept the PTP set-config command without applying it — the read-back
+  check makes this visible in the log and console so the user knows to set the aperture
+  manually on the lens or camera body.
+
 ## [1.9.0] - 2026-04-17
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "solareclipseworkbench"
-version = "1.9.0"
+version = "1.9.1"
 
 description = "Tools to photograph solar eclipses"
 readme = "README.md"

--- a/scripts/print_fnumber_choices.py
+++ b/scripts/print_fnumber_choices.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Print the available f-number choices reported by the connected camera via gphoto2.
+
+Run this script with the camera connected and switched on (in PC Remote / MTP mode).
+It will show exactly what strings gphoto2 exposes for the f-number widget, which is
+the information needed to diagnose aperture-setting failures.
+"""
+
+import sys
+
+try:
+    import gphoto2 as gp
+except ImportError:
+    sys.exit("gphoto2 Python bindings not found.  Install them with:  pip install gphoto2")
+
+context = gp.Context()
+camera = gp.Camera()
+
+print("Connecting to camera …")
+try:
+    camera.init(context)
+except gp.GPhoto2Error as e:
+    sys.exit(f"Could not connect to camera: {e}\n"
+             "Make sure the camera is on, connected via USB, and in PC Remote mode.")
+
+try:
+    config = camera.get_config(context)
+
+    # Try the 'f-number' widget name (Nikon/Sony via PTP)
+    widget_names = ['f-number', 'aperture']
+    f_widget = None
+    used_name = None
+    for name in widget_names:
+        try:
+            f_widget = config.get_child_by_name(name)
+            used_name = name
+            break
+        except gp.GPhoto2Error:
+            pass
+
+    if f_widget is None:
+        print("Neither 'f-number' nor 'aperture' widget found on this camera.")
+        print("Available top-level config children:")
+        for child in config.get_children():
+            print(f"  {child.get_name()}")
+    else:
+        current = f_widget.get_value()
+        print(f"Widget name : '{used_name}'")
+        print(f"Current value: {current!r}")
+        print()
+        try:
+            n = f_widget.count_choices()
+            print(f"{n} available choice(s):")
+            for i in range(n):
+                choice = f_widget.get_choice(i)
+                marker = "  <-- current" if choice == current else ""
+                print(f"  [{i:3d}]  {choice!r}{marker}")
+        except gp.GPhoto2Error:
+            print("(Widget has no enumerated choices — it may accept free-form values.)")
+finally:
+    camera.exit(context)
+    print("\nDone.")

--- a/src/solareclipseworkbench/camera.py
+++ b/src/solareclipseworkbench/camera.py
@@ -16,6 +16,18 @@ class CameraError(Exception):
     pass
 
 
+def _is_sony_model(name: str) -> bool:
+    """Return True when a camera model string represents a Sony body.
+
+    gphoto2 may report Sony cameras either with an explicit "Sony" prefix
+    (for example "Sony Alpha-A7 IV") or as ILCE model codes
+    (for example "ILCE-7M5"). Treat both as Sony so vendor-specific
+    behavior is applied consistently.
+    """
+    upper_name = (name or "").upper()
+    return "SONY" in upper_name or upper_name.startswith("ILCE-")
+
+
 def _set_gp_config(camera, config, context):
     """Set camera config using underlying gphoto object when wrapped by adapter."""
     target = camera._camera if hasattr(camera, '_camera') else camera
@@ -36,6 +48,13 @@ def _normalise_aperture(value: str) -> str:
     except ValueError:
         pass
     return value
+
+
+# Per-camera aperture verification cache.  Maps camera_name -> set of aperture strings
+# that have already been checked via a read-back round-trip.  Once an aperture value
+# has been verified (or a mismatch has been warned about) for a given camera, subsequent
+# shots skip the extra USB get_config call to avoid adding latency to tight sequences.
+_aperture_verified: dict[str, set] = {}
 
 
 class CameraSettings:
@@ -246,7 +265,7 @@ class GPhotoCameraAdapter(BaseCamera):
             self.vendor = 'Canon'
         elif 'Nikon' in name:
             self.vendor = 'Nikon'
-        elif 'Sony' in name:
+        elif _is_sony_model(name):
             self.vendor = 'Sony'
         else:
             self.vendor = None
@@ -398,7 +417,7 @@ def _raise_camera_init_error(camera_name: str, error: Exception) -> None:
         sony_note = (
             "\nNOTE: Sony cameras must have PC Remote mode enabled on the camera: "
             "Menu → Network → PC Remote Settings → PC Remote → On."
-            if 'Sony' in camera_name else ''
+            if _is_sony_model(camera_name) else ''
         )
         raise CameraError(
             f"Cannot claim USB device for '{camera_name}' (gphoto2 error -53 — device busy).\n"
@@ -730,7 +749,9 @@ class LiveViewThread(threading.Thread):
     def run(self):
         # If the camera provides a capture_preview() method (e.g. VirtualCamera
         # in simulator mode), use that path — no gphoto2 calls or USB lock needed.
-        _has_virtual_preview = callable(getattr(self._camera, 'capture_preview', None))
+        # Do not use this path for wrapped gphoto2 cameras: delegated
+        # capture_preview() may return a CameraFile object (not JPEG bytes).
+        _has_virtual_preview = isinstance(self._camera, VirtualCamera)
 
         target = None
         context = None
@@ -745,6 +766,10 @@ class LiveViewThread(threading.Thread):
             if _has_virtual_preview:
                 try:
                     jpeg_bytes = self._camera.capture_preview()
+                    if isinstance(jpeg_bytes, memoryview):
+                        jpeg_bytes = jpeg_bytes.tobytes()
+                    elif isinstance(jpeg_bytes, bytearray):
+                        jpeg_bytes = bytes(jpeg_bytes)
                     if jpeg_bytes:
                         self._frame_callback(jpeg_bytes)
                 except Exception:
@@ -1021,6 +1046,36 @@ def __adapt_camera_settings(camera, camera_settings):
                 raise
         _set_gp_config(target, config, context)
         logging.debug('Set aperture to %s', camera_settings.aperture)
+
+        # Read-back check: verify the camera actually applied the requested aperture.
+        # Some Sony Alpha bodies (and other cameras) silently accept set_config via PTP
+        # without changing the physical aperture — no error is raised, but the setting
+        # is ignored.  Reading the value back catches this case and emits a warning.
+        #
+        # The check is skipped once a particular (camera, aperture) pair has already been
+        # verified to avoid an extra USB round-trip on every shot in a tight sequence.
+        cam_key = camera_settings.camera_name
+        ap_key = str(camera_settings.aperture)
+        if ap_key not in _aperture_verified.get(cam_key, set()):
+            try:
+                config_rb = gp.check_result(gp.gp_camera_get_config(target, context))
+                widget_name = 'aperture' if vendor == 'Canon' else 'f-number'
+                rb_widget = gp.check_result(gp.gp_widget_get_child_by_name(config_rb, widget_name))
+                actual = str(gp.check_result(gp.gp_widget_get_value(rb_widget)))
+
+                def _strip_f(v: str) -> str:
+                    return v[2:] if v.startswith('f/') else v
+
+                if _strip_f(actual) != _strip_f(ap_key):
+                    logging.warning(
+                        'Aperture read-back mismatch on %s: requested f/%s but camera reports %s. '
+                        'The camera may not support remote aperture control via USB — '
+                        'set the aperture manually on the lens/camera body.',
+                        cam_key, _strip_f(ap_key), actual)
+                # Mark as checked regardless — mismatch or not, no point repeating the warning.
+                _aperture_verified.setdefault(cam_key, set()).add(ap_key)
+            except gphoto2.GPhoto2Error:
+                pass  # Read-back failure is non-fatal
     except gphoto2.GPhoto2Error:
         # Read-only or absent aperture widget (telescope, fixed-aperture lens) — ignore.
         logging.debug('Aperture widget not settable (telescope/fixed lens) — skipping')
@@ -1132,8 +1187,15 @@ def take_burst(camera: Camera, camera_settings: CameraSettings, duration: float)
         except gphoto2.GPhoto2Error as e:
             logging.warning('Could not reset Nikon burstnumber to 1 after burst: %s', e)
     elif getattr(camera, 'vendor', None) == 'Sony':
-        # Sony burst: enable continuous capture mode, fire N gp_camera_trigger_capture
+        # Sony burst: enable continuous capture mode, fire N trigger_capture
         # calls (duration = number of frames), then reset to single-shot mode.
+        # Sony Alpha bodies do not emit GP_EVENT_CAPTURE_COMPLETE, so reusing
+        # _wait_for_capture_complete here adds an unnecessary ~3 s timeout after
+        # every frame.  That stretches a 30-frame C2 burst into ~90 s, causing
+        # nearby scheduled jobs to be dropped by the USB-lock timing guard.
+        # Keep burst handling aligned with the Sony take_picture path instead:
+        # drain stale queued events before each trigger, then drain the short
+        # initial property-change burst without waiting for card-write events.
         n_frames = max(1, int(round(duration)))
         target = camera._camera if hasattr(camera, '_camera') else camera
 
@@ -1154,9 +1216,10 @@ def take_burst(camera: Camera, camera_settings: CameraSettings, duration: float)
         # Fire N individually-triggered captures
         for i in range(n_frames):
             try:
+                _sony_drain_events(target, context)
                 gp.check_result(gp.gp_camera_trigger_capture(target, context))
                 logging.debug('Sony burst: triggered capture %d/%d', i + 1, n_frames)
-                _wait_for_capture_complete(target, context)
+                _drain_camera_events(target, context, timeout_ms=100, max_events=60)
             except gphoto2.GPhoto2Error as e:
                 logging.warning('Sony burst: capture %d/%d failed: %s', i + 1, n_frames, e)
                 try:
@@ -1535,7 +1598,7 @@ def get_camera(camera_name: str):
     elif "Nikon" in camera_name:
         logging.debug('Wrapping camera %s as NikonCamera', camera_name)
         return NikonCamera(camera, camera_name)
-    elif "Sony" in camera_name:
+    elif _is_sony_model(camera_name):
         logging.debug('Wrapping camera %s as SonyCamera', camera_name)
         return SonyCamera(camera, camera_name)
     else:
@@ -1612,7 +1675,7 @@ def get_camera_by_port(model_name: str, port: str, alias: Optional[str] = None) 
     elif "Nikon" in model_name:
         logging.debug('Wrapping camera %s as NikonCamera (alias=%s)', model_name, alias)
         return NikonCamera(camera, display_name)
-    elif "Sony" in model_name:
+    elif _is_sony_model(model_name):
         logging.debug('Wrapping camera %s as SonyCamera (alias=%s)', model_name, alias)
         return SonyCamera(camera, display_name)
     else:
@@ -1852,7 +1915,12 @@ def get_focus_mode(camera: Camera) -> str:
     """
 
     try:
-        return camera.get_config().get_child_by_name('focusmode').get_value()
+        value = camera.get_config().get_child_by_name('focusmode').get_value()
+        # gphoto2 may return localized strings (e.g. German "Manuell") or "undefined"
+        # when the camera reports manual focus via the lens/body switch.
+        if value is None or value.lower() in ('manuell', 'undefined', 'manual'):
+            return 'Manual'
+        return value
     except gphoto2.GPhoto2Error as e:
         logging.warning('gphoto2 error reading focus mode for %s: %s', getattr(camera, 'name', str(camera)), e)
         return "Manual"
@@ -2372,6 +2440,34 @@ def get_sony_save_destination(camera) -> str | None:
         return _walk(cfg)
     except Exception:
         return None
+
+
+def sony_save_destination_needs_downloader(destination: Optional[str]) -> bool:
+    """Return True only when destination string clearly indicates PC-only save.
+
+    Destination values differ across camera firmwares and locales.  This helper
+    intentionally errs on the side of *not* downloading when unclear, to avoid
+    stealing USB bandwidth from scheduled captures.
+    """
+    if destination is None:
+        return False
+
+    value = str(destination).strip().lower()
+    if not value:
+        return False
+
+    has_pc = ('pc' in value) or ('computer' in value)
+    has_camera_or_card = any(
+        token in value
+        for token in ('camera', 'camara', 'kamera', 'card', 'sd')
+    )
+
+    # Explicit mixed destinations like "PC+Camera" or "PC/Camera".
+    if has_pc and has_camera_or_card:
+        return False
+
+    # Any destination mentioning only PC/computer should enable downloading.
+    return has_pc and not has_camera_or_card
 
 
 if __name__ == "__main__":

--- a/src/solareclipseworkbench/gui.py
+++ b/src/solareclipseworkbench/gui.py
@@ -40,7 +40,8 @@ from skyfield.api import load, wgs84
 import threading
 
 from solareclipseworkbench.camera import get_camera_dict, get_battery_level, get_free_space, get_space, \
-    get_shooting_mode, get_focus_mode, set_time, CameraSettings, LiveViewThread
+    get_shooting_mode, get_focus_mode, set_time, CameraSettings, LiveViewThread, \
+    sony_save_destination_needs_downloader
 from solareclipseworkbench.observer import Observer, Observable
 from solareclipseworkbench.qt_utils import apply_system_color_scheme
 from solareclipseworkbench.reference_moments import calculate_reference_moments, ReferenceMomentInfo
@@ -2127,6 +2128,14 @@ class LiveViewWindow(QWidget):
             jpeg_bytes, ts = self._frame_queue.get_nowait()
         except queue.Empty:
             return
+        if isinstance(jpeg_bytes, memoryview):
+            jpeg_bytes = jpeg_bytes.tobytes()
+        elif isinstance(jpeg_bytes, bytearray):
+            jpeg_bytes = bytes(jpeg_bytes)
+        elif not isinstance(jpeg_bytes, bytes):
+            LOGGER.warning("Live view frame had unsupported type: %s", type(jpeg_bytes).__name__)
+            return
+
         image = QImage.fromData(jpeg_bytes)
         if image.isNull():
             return
@@ -2479,11 +2488,11 @@ class CameraOverviewTableModel(QAbstractTableModel):
                                 pass
                             continue
                         dest = get_sony_save_destination(cam)
-                        # If the save-destination widget is not exposed via gphoto2
-                        # (dest is None) the camera may still be in PC-only mode
-                        # and we should start the downloader. Also start when the
-                        # camera explicitly reports 'PC Only'.
-                        if dest is None or 'pc only' in dest.lower():
+                        # Start downloader only when destination clearly says
+                        # PC-only. If destination is unavailable (common with
+                        # localized camera menus), avoid downloading to protect
+                        # shot timing.
+                        if sony_save_destination_needs_downloader(dest):
                             try:
                                 cam.start_background_downloader()
                             except Exception:

--- a/tests/test_live_view_preview_types.py
+++ b/tests/test_live_view_preview_types.py
@@ -1,0 +1,71 @@
+import threading
+from unittest.mock import patch
+
+from solareclipseworkbench.camera import LiveViewThread
+
+
+class _DummyLock:
+    def __init__(self):
+        self.acquire_calls = 0
+        self.release_calls = 0
+
+    def acquire(self, timeout=None):
+        self.acquire_calls += 1
+        return True
+
+    def release(self):
+        self.release_calls += 1
+
+
+class _DelegatingPreviewCamera:
+    """Camera-like object that exposes capture_preview but is not VirtualCamera.
+
+    This mirrors wrapped gphoto camera adapters that can surface a delegated
+    capture_preview() method. LiveViewThread must not treat this as virtual mode.
+    """
+
+    def __init__(self):
+        self._camera = object()
+        self._usb_lock = _DummyLock()
+        self.capture_preview_calls = 0
+
+    def capture_preview(self):
+        self.capture_preview_calls += 1
+        return object()
+
+
+def test_live_view_thread_uses_gphoto_path_for_non_virtual_capture_preview():
+    camera = _DelegatingPreviewCamera()
+    got_frame = threading.Event()
+    received = []
+
+    def _on_frame(jpeg_bytes):
+        received.append(jpeg_bytes)
+        got_frame.set()
+
+    expected_bytes = b"\xff\xd8jpeg-preview\xff\xd9"
+
+    with patch("solareclipseworkbench.camera.gp.gp_context_new", return_value=object()), \
+         patch("solareclipseworkbench.camera.gp.CameraFile", return_value=object()) as camera_file_ctor, \
+         patch("solareclipseworkbench.camera.gp.gp_camera_capture_preview", return_value=0) as capture_preview_call, \
+         patch("solareclipseworkbench.camera.gp.gp_file_get_data_and_size", return_value=expected_bytes), \
+         patch("solareclipseworkbench.camera.gp.check_result", side_effect=lambda x: x):
+
+        thread = LiveViewThread(camera=camera, frame_callback=_on_frame, interval_s=0.001, lock_timeout=0.01)
+        thread.start()
+        try:
+            assert got_frame.wait(0.5), "Timed out waiting for a preview frame"
+        finally:
+            thread.stop()
+            thread.join(timeout=1.0)
+
+    assert received, "No preview frame was delivered"
+    assert isinstance(received[0], bytes)
+    assert received[0] == expected_bytes
+
+    # Regression check: non-virtual camera must not go down the delegated capture_preview path.
+    assert camera.capture_preview_calls == 0
+
+    # gphoto path should have been used.
+    assert camera_file_ctor.called
+    assert capture_preview_call.called

--- a/tests/test_sony_burst.py
+++ b/tests/test_sony_burst.py
@@ -1,0 +1,44 @@
+from unittest.mock import patch
+
+from solareclipseworkbench.camera import CameraSettings, take_burst
+
+
+class _DummyLock:
+    def acquire(self, timeout=None):
+        return True
+
+    def release(self):
+        return None
+
+
+class _SonyCamera:
+    def __init__(self):
+        self.vendor = "Sony"
+        self._camera = object()
+        self._usb_lock = _DummyLock()
+
+    def capture(self, *args, **kwargs):
+        raise AssertionError("fallback capture should not be used in this regression test")
+
+
+def test_take_burst_uses_sony_event_drain_instead_of_capture_complete_wait():
+    camera = _SonyCamera()
+    settings = CameraSettings("Sony Test", "1/2000", "5.6", 100)
+
+    with patch("solareclipseworkbench.camera.__adapt_camera_settings", return_value=(object(), object())), \
+         patch("solareclipseworkbench.camera.gp.check_result", side_effect=lambda value: value), \
+         patch("solareclipseworkbench.camera.gp.gp_widget_get_child_by_name", return_value=object()), \
+         patch("solareclipseworkbench.camera.gp.gp_widget_set_value"), \
+         patch("solareclipseworkbench.camera.gp.gp_camera_trigger_capture", return_value=0) as trigger_capture, \
+         patch("solareclipseworkbench.camera.gp.gp_camera_get_config", return_value=object()), \
+         patch("solareclipseworkbench.camera._find_capturemode_choice", side_effect=["Continuous Shooting", "Single Shooting"]), \
+         patch("solareclipseworkbench.camera._set_gp_config"), \
+         patch("solareclipseworkbench.camera._sony_drain_events") as sony_drain, \
+         patch("solareclipseworkbench.camera._drain_camera_events") as drain_events, \
+         patch("solareclipseworkbench.camera._wait_for_capture_complete") as wait_for_capture_complete:
+        take_burst(camera, settings, 3)
+
+    assert trigger_capture.call_count == 3
+    assert sony_drain.call_count == 3
+    assert drain_events.call_count == 3
+    wait_for_capture_complete.assert_not_called()

--- a/tests/test_sony_save_destination.py
+++ b/tests/test_sony_save_destination.py
@@ -1,0 +1,28 @@
+"""Unit tests for Sony save-destination downloader decision logic."""
+
+import unittest
+
+from src.solareclipseworkbench.camera import sony_save_destination_needs_downloader
+
+
+class TestSonySaveDestinationNeedsDownloader(unittest.TestCase):
+    def test_none_or_empty_is_not_pc_only(self):
+        self.assertFalse(sony_save_destination_needs_downloader(None))
+        self.assertFalse(sony_save_destination_needs_downloader(""))
+        self.assertFalse(sony_save_destination_needs_downloader("   "))
+
+    def test_pc_only_variants_enable_downloader(self):
+        self.assertTrue(sony_save_destination_needs_downloader("PC Only"))
+        self.assertTrue(sony_save_destination_needs_downloader("pc-only"))
+        self.assertTrue(sony_save_destination_needs_downloader("Computer only"))
+        self.assertTrue(sony_save_destination_needs_downloader("Nur PC"))
+
+    def test_mixed_or_camera_destinations_disable_downloader(self):
+        self.assertFalse(sony_save_destination_needs_downloader("PC+Camera"))
+        self.assertFalse(sony_save_destination_needs_downloader("PC/Camera"))
+        self.assertFalse(sony_save_destination_needs_downloader("Camera Only"))
+        self.assertFalse(sony_save_destination_needs_downloader("PC+Camara"))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/uv.lock
+++ b/uv.lock
@@ -47,11 +47,11 @@ wheels = [
 
 [[package]]
 name = "astropy-iers-data"
-version = "0.2026.4.13.0.58.2"
+version = "0.2026.4.20.0.58.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/51/4a/5ebf17e2a2bf82747641c66babce54295239f10b315bdb36d076429fd048/astropy_iers_data-0.2026.4.13.0.58.2.tar.gz", hash = "sha256:a079f31cd3e235afd9b9d435be53fc69ae619aef93339c54863767c3c76e4807", size = 1930728, upload-time = "2026-04-13T00:58:40.001Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7f/24/7f977f00017c6f4c200585f3333cdfa7d018bfc236851d8885a08aae09ac/astropy_iers_data-0.2026.4.20.0.58.15.tar.gz", hash = "sha256:f54c3ecf435c8d7fe627dee7e75c5bc390beac3f3350b36b04730b54df72ccf1", size = 1931255, upload-time = "2026-04-20T00:58:59.123Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/c7/da797a2ae6a64c27553871ff2c3bf64343970efce730b3247e6bd2c00994/astropy_iers_data-0.2026.4.13.0.58.2-py3-none-any.whl", hash = "sha256:f93d788bda4b0b20dfc7672719699178c106ddd15e2048069a6f74ee7cf2a7ef", size = 1987515, upload-time = "2026-04-13T00:58:38.753Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/fe/6dc92a96bed2703e86dba2d46d4a66ebb1f275054dcce4c6299e0ef9b492/astropy_iers_data-0.2026.4.20.0.58.15-py3-none-any.whl", hash = "sha256:37e9c1c32215584067a55839b8ce744cf0b3b0a30b7ebebc2d1e908b0556a24d", size = 1988029, upload-time = "2026-04-20T00:58:57.323Z" },
 ]
 
 [[package]]
@@ -1455,7 +1455,7 @@ wheels = [
 
 [[package]]
 name = "solareclipseworkbench"
-version = "1.9.0"
+version = "1.9.1"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
Treats ILCE-prefixed model names as Sony so vendor-specific behavior and adapters apply consistently.

Normalizes focus-mode values (localized "Manuell" and firmware "undefined") to "Manual" to avoid spurious warnings.

Prevents background downloader from starting on unknown or localized save-destination values; enables downloading only when destination clearly indicates PC-only to avoid stealing USB bandwidth from scheduled captures.

Fixes live-preview crash by ensuring wrapped gphoto cameras use the gphoto preview path (deliver raw bytes); normalizes memoryview/bytearray frames to bytes and safely skips unsupported frame types.

Speeds up Sony burst capture by avoiding capture-complete waits and using event draining around triggers to prevent long per-frame delays.

Adds an aperture read-back verification with a per-camera cache and a warning when the camera reports a different f-number, making ignored USB aperture commands visible to the user.

Adds regression tests for preview frame types, Sony save-destination logic, and Sony burst handling; adds a helper script to dump f-number choices. Bumps version to 1.9.1 and updates the changelog.