### PR TITLE
Fix headless command-line simulation (sew.py)

### DIFF
--- a/src/solareclipseworkbench/sew.py
+++ b/src/solareclipseworkbench/sew.py
@@ -3,7 +3,7 @@ from time import sleep
 
 from astropy.time import Time
 
-import camera
+from solareclipseworkbench import camera
 from solareclipseworkbench import gui
 from solareclipseworkbench.location_ui import ConfigManager
 from solareclipseworkbench.reference_moments import calculate_reference_moments
@@ -15,7 +15,11 @@ def main(args):
         gui.main()
     else:
         # Check for all needed parameters
-        if args.date and args.longitude and args.latitude and args.altitude and args.script:
+        # Use "is not False" rather than truthiness: an altitude (or longitude/
+        # latitude) of 0 is valid but falsy, and would otherwise be rejected.
+        if (args.date is not False and args.longitude is not False
+                and args.latitude is not False and args.altitude is not False
+                and args.script is not False):
             eclipse_date = Time(args.date)
             timings, magnitude, eclipse_type = calculate_reference_moments(args.longitude, args.latitude, args.altitude,
                                                                            eclipse_date)

--- a/src/solareclipseworkbench/utils.py
+++ b/src/solareclipseworkbench/utils.py
@@ -71,10 +71,14 @@ def observe_solar_eclipse(ref_moments: dict, commands_filename: str, cameras: di
         simulated_start = now + timedelta(minutes=minutes_to_reference_moment)
 
         offset = ref_moments[reference_moment].time_utc - timedelta(minutes=minutes_to_reference_moment) - now
-        controller.view.eclipse_visualization.set_offset(offset)
     else:
         simulated_start = None
-        controller.view.eclipse_visualization.set_offset(timedelta(minutes=0))
+        offset = timedelta(minutes=0)
+
+    # Update the visualization offset only when running with a GUI; the headless
+    # command-line path (sew.py without --gui) has no controller/view.
+    if controller is not None:
+        controller.view.eclipse_visualization.set_offset(offset)
 
     # Schedule commands
     schedule_commands(commands_filename, scheduler, ref_moments, cameras, controller, reference_moment, simulated_start,


### PR DESCRIPTION
Running an eclipse simulation from the command line — `python -m solareclipseworkbench.sew` without `--gui` — currently fails. Three small issues in the headless path, all introduced/uncovered by the `src/` layout migration:

1. **`sew.py` uses a bare `import camera`.** That only resolves when the package directory itself is on `sys.path` (i.e. running the file as a script). Run as a module it raises `ModuleNotFoundError`. Changed to `from solareclipseworkbench import camera`.

2. **The CLI argument check rejects a valid altitude of `0`.** `if args.date and args.longitude and args.latitude and args.altitude and args.script:` tests truthiness, and `0.0` is falsy — so a sea-level location (`-alt 0`) prints "you must specify the date, script ... and the exact location" even though everything was supplied. Changed to `is not False` checks (the argparse default is `False`), which also covers a `0` longitude/latitude.

3. **`observe_solar_eclipse` dereferences `controller.view` unconditionally.** The headless path passes `controller=None`, so it crashes with `AttributeError: 'NoneType' object has no attribute 'view'` as soon as a simulation reference moment is given. Guarded the visualization update so it only runs when a GUI controller is present.

### Before
```
$ python -m solareclipseworkbench.sew -d 2026-08-12 -lat 41.5 -lon -5.0 -alt 0 -s script.txt -r C1 -m 1
...
AttributeError: 'NoneType' object has no attribute 'view'
```

### After
The same command schedules and runs the simulation headless (cameras fire on the configured schedule, no GUI required).

No behavioural change to the GUI path.