### PR TITLE
Stop the previous scheduler when a new script is loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [2.0.0rc1] - 2026-07-31
+
+### Fixed
+
+- Stop the previous scheduler when a new script is loaded- #163 by @mrosseel
+  - Loading a second script left two schedulers running and every command fired twice.
+
 ## [1.10.7] - 2026-07-23
 
 ### Fixed

--- a/src/solareclipseworkbench/gui.py
+++ b/src/solareclipseworkbench/gui.py
@@ -1245,6 +1245,13 @@ class SolarEclipseController(Observer):
                 )
                 return
 
+            # Loading a script always starts a *new* scheduler, so any scheduler from a
+            # previously loaded script must be stopped first — otherwise both stay alive and
+            # every command fires twice.
+            if self.scheduler:
+                LOGGER.info("Replacing the previously loaded script")
+                self._shutdown_scheduler()
+
             try:
                 from solareclipseworkbench.utils import observe_solar_eclipse
                 self.scheduler: BackgroundScheduler \


### PR DESCRIPTION
# Summary of the changes
- `observe_solar_eclipse()` calls `start_scheduler()` and returns a **new** scheduler every time, but the previous one was only shut down when the application exited. Loading a second script therefore left two schedulers running and **every command fired twice**.
- The failure is silent: the jobs table is rebuilt from the new scheduler, so it shows each command once while the old scheduler keeps firing its own copies in the background. It is most likely to happen exactly when it hurts most — loading a corrected script during setup on eclipse day.
- Fix reuses the existing `_shutdown_scheduler()`, which also clears the jobs overview and re-enables the Camera(s) button, so an edited script can be re-loaded without restarting the application.

# Related issues
- None

# Test results
- Existing test suite passes (11 passed).
- Verified by loading a script twice in a simulated run: previously each command was scheduled twice (once per live scheduler) with the jobs table showing only one copy; after the change the second load replaces the first cleanly.

# Note
- This also makes the edit-script → reload loop usable, which previously required an application restart.