### PR TITLE
Close every camera on exit, not just up to the first failure

### DIFF
--- a/src/solareclipseworkbench/gui.py
+++ b/src/solareclipseworkbench/gui.py
@@ -1099,7 +1099,15 @@ class SolarEclipseController(Observer):
 
                 camera: Camera
                 for camera in cameras:
-                    camera.exit()
+                    # Close every camera even if one refuses.  Without this, the
+                    # first camera to raise aborts the loop and leaves the rest
+                    # open, still holding their USB devices, so the next run
+                    # cannot claim them and fails with a device-busy error.
+                    try:
+                        camera.exit()
+                    except Exception:
+                        LOGGER.exception("Could not close camera %s",
+                                         getattr(camera, "name", camera))
 
             return
 


### PR DESCRIPTION
## Problem

The shutdown loop in `gui.py` calls `camera.exit()` without guarding it:

```python
camera: Camera
for camera in cameras:
    camera.exit()
```

If one camera raises — a USB device that has already gone away, a body that has powered off, a stale handle — the exception escapes the loop and **every remaining camera is left open**, still holding its USB device.

The next run then cannot claim those cameras and fails with a device-busy error until they are physically replugged. With a single camera this is invisible; with two or more it looks like a random failure to detect the second camera.

## Fix

Close each camera independently, and log any that refuse.

## Notes

Found while reviewing multi-camera shutdown. No behaviour change when every camera closes cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dwu2e9budQMUGgrWZtoxY5