### PR TITLE
Show camera problems in the GUI instead of only in the log

### DIFF
--- a/src/solareclipseworkbench/gui.py
+++ b/src/solareclipseworkbench/gui.py
@@ -42,6 +42,7 @@ import threading
 from solareclipseworkbench.camera import get_camera_dict, get_battery_level, get_free_space, get_space, \
     get_shooting_mode, get_focus_mode, set_time, CameraSettings, LiveViewThread, \
     sony_save_destination_needs_downloader
+from solareclipseworkbench import hardware_problems
 from solareclipseworkbench.observer import Observer, Observable
 from solareclipseworkbench.qt_utils import apply_system_color_scheme
 from solareclipseworkbench.reference_moments import calculate_reference_moments, ReferenceMomentInfo
@@ -924,6 +925,13 @@ class SolarEclipseController(Observer):
         self.time_display_timer.setInterval(1000)
         self.time_display_timer.start()
 
+        # Camera problems are raised on worker threads, which cannot open a
+        # dialog, so they are queued and collected here on the UI thread.
+        self._problem_timer = QTimer()
+        self._problem_timer.timeout.connect(self._show_camera_problems)
+        self._problem_timer.setInterval(2000)
+        self._problem_timer.start()
+
         # Update the eclipse visualization less frequently to save CPU/battery.
         # The main time display remains at 1 Hz; the plot updates every 5 seconds.
         self.visualization_timer = QTimer()
@@ -936,6 +944,47 @@ class SolarEclipseController(Observer):
         self._live_view_window: Union[LiveViewWindow, None] = None
 
         self.load_settings()
+
+    def _run_in_progress(self) -> bool:
+        """True while a schedule is loaded and running."""
+        try:
+            return bool(self.scheduler and self.scheduler.get_jobs())
+        except Exception:
+            return False
+
+    def _show_camera_problems(self):
+        """Show queued camera problems, without ever interrupting a run.
+
+        Before the run a dialog is right: that is when a camera that failed to
+        respond can still be replugged or swapped.  Once the schedule is
+        running a modal dialog is worse than the problem it reports, because it
+        blocks the UI thread while frames are being taken, so the count goes in
+        the window title instead and the detail stays in the log.
+        """
+        try:
+            if hardware_problems.count() == 0:
+                return
+
+            if self._run_in_progress():
+                pending = hardware_problems.peek()
+                worst = "error" if any(p.severity == "error" for p in pending) else "warning"
+                marker = "\u26d4" if worst == "error" else "\u26a0"
+                self.view.setWindowTitle(
+                    f"{marker} {len(pending)} camera problem(s) - Solar Eclipse Workbench"
+                )
+                return
+
+            problems = hardware_problems.drain()
+            summary = hardware_problems.summarise(problems)
+            has_error = any(p.severity == "error" for p in problems)
+            box = QMessageBox.critical if has_error else QMessageBox.warning
+            box(
+                self.view,
+                "Camera problem" if len(problems) == 1 else "Camera problems",
+                summary + "\n\nDetails are in the log file.",
+            )
+        except Exception:
+            LOGGER.exception("Could not display camera problems")
 
     def update_time(self):
         """ Update the displayed current time and countdown clocks."""
@@ -2762,8 +2811,16 @@ class CameraOverviewTableModel(QAbstractTableModel):
                         free_space_gb_str = str(free_space_gb)
                         free_space_pct_str = str(int(free_space_gb / total_space * 100))
                     data.append([camera_name, str(battery_level), free_space_gb_str, free_space_pct_str])
-                except Exception:
+                except Exception as exc:
                     logging.exception('Worker: exception while processing camera %s', camera_name)
+                    # The row survives with N/A values, which on its own looks
+                    # like the camera is simply idle.  Say why.
+                    hardware_problems.report(
+                        str(camera_name),
+                        'Could not read battery and free space from this camera',
+                        detail=str(exc),
+                        severity='warning',
+                    )
                     # Preserve the camera row with N/A values when probing fails so
                     # the camera does not disappear from the UI.
                     try:
@@ -2783,8 +2840,13 @@ class CameraOverviewTableModel(QAbstractTableModel):
                 self._pending_camera_map = camera_dict
             except Exception:
                 logging.exception('Worker: could not set pending data')
-        except Exception:
+        except Exception as exc:
             logging.exception('Worker: failed to gather camera info')
+            hardware_problems.report(
+                'Cameras',
+                'Could not read the connected cameras',
+                detail=str(exc),
+            )
 
     def _on_data_ready(self, data):
         try:

--- a/src/solareclipseworkbench/hardware_problems.py
+++ b/src/solareclipseworkbench/hardware_problems.py
@@ -1,0 +1,143 @@
+"""A channel for hardware problems that the user has to know about.
+
+Camera work happens on worker threads, so it cannot raise a dialog directly.
+Problems are queued here and drained by the GUI on its own thread, following the
+same pattern the camera overview already uses for its results.
+
+Two rules shape this:
+
+*Say it early.*  Anything checkable before the eclipse — a camera that did not
+appear, a setting that will spoil the frames — should be reported the moment the
+camera is connected, while there is still time to walk over and fix it.
+
+*Say it quietly once the run has started.*  While a script is executing, a modal
+dialog is worse than the problem it describes: it stalls the application at the
+exact moment frames are being taken.  Repeats are therefore folded together with
+a count, and the GUI shows them as an indicator during a run and only opens a
+dialog when the schedule is not running.
+"""
+
+import logging
+import threading
+import time
+from collections import OrderedDict
+from dataclasses import dataclass, field
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Distinct problems worth remembering.  Repeats of the same problem increment a
+# count rather than taking a new slot, so a failure in a tight loop cannot push
+# everything else out.
+_MAX_PROBLEMS = 50
+
+# How often the same problem may be logged.  The count keeps rising regardless;
+# this only stops the log filling with one repeated line.
+_LOG_INTERVAL_S = 5.0
+
+_problems: OrderedDict = OrderedDict()
+_lock = threading.Lock()
+
+
+@dataclass
+class Problem:
+    """Something the user needs to see, not just something that got logged."""
+
+    source: str                 # "Fuji SDK", "X-T4", ...
+    message: str                # one line, plain language
+    detail: str = ""            # optional specifics
+    severity: str = "error"     # "error" | "warning"
+    count: int = 1
+    first_seen: float = 0.0
+    last_seen: float = 0.0
+    context: dict = field(default_factory=dict)
+
+    @property
+    def key(self) -> tuple:
+        return (self.source, self.message)
+
+    def __str__(self) -> str:
+        text = f"{self.source}: {self.message}"
+        if self.detail:
+            text += f" ({self.detail})"
+        if self.count > 1:
+            text += f" [x{self.count}]"
+        return text
+
+
+def report(source: str, message: str, detail: str = "", severity: str = "error",
+           **context) -> None:
+    """Queue a problem for the GUI, and log it at a level that matches.
+
+    Safe to call from any thread.  Never raises: reporting a problem must not
+    itself become one.  Repeats of the same (source, message) are folded into a
+    count instead of queuing again.
+    """
+    try:
+        now = time.time()
+        key = (source, message)
+        should_log = True
+
+        with _lock:
+            existing = _problems.get(key)
+            if existing is not None:
+                existing.count += 1
+                existing.last_seen = now
+                if existing.detail != detail and detail:
+                    existing.detail = detail
+                should_log = (now - existing.context.get("_logged_at", 0.0)) >= _LOG_INTERVAL_S
+                if should_log:
+                    existing.context["_logged_at"] = now
+                problem = existing
+            else:
+                problem = Problem(source=source, message=message, detail=detail,
+                                  severity=severity, first_seen=now, last_seen=now,
+                                  context=dict(context, _logged_at=now))
+                _problems[key] = problem
+                if len(_problems) > _MAX_PROBLEMS:
+                    _problems.popitem(last=False)
+
+        if should_log:
+            log = logger.error if severity == "error" else logger.warning
+            log("%s", problem)
+    except Exception:
+        logger.debug("Failed to report a hardware problem", exc_info=True)
+
+
+def drain() -> list:
+    """Take every queued problem, leaving the queue empty."""
+    with _lock:
+        taken = list(_problems.values())
+        _problems.clear()
+    return taken
+
+
+def peek() -> list:
+    """Look at queued problems without consuming them."""
+    with _lock:
+        return list(_problems.values())
+
+
+def count() -> int:
+    """How many distinct problems are waiting."""
+    with _lock:
+        return len(_problems)
+
+
+def clear() -> None:
+    with _lock:
+        _problems.clear()
+
+
+def summarise(problems: Optional[list] = None) -> str:
+    """Fold a list of problems into one block of text for a dialog or banner."""
+    problems = peek() if problems is None else problems
+    if not problems:
+        return ""
+    lines = []
+    for problem in problems:
+        suffix = f"  (x{problem.count})" if problem.count > 1 else ""
+        lines.append(f"• {problem.message}{suffix}")
+        if problem.detail:
+            lines.append(f"    {problem.detail}")
+    return "\n".join(lines)

--- a/tests/test_hardware_problems.py
+++ b/tests/test_hardware_problems.py
@@ -1,0 +1,78 @@
+"""The rule these tests exist to defend: a hardware failure is never silent.
+
+Anything that changes what lands on the memory card has to reach the person at
+the telescope, and repeats must not turn into a flood.
+"""
+
+import pytest
+
+from solareclipseworkbench import hardware_problems
+
+
+@pytest.fixture(autouse=True)
+def _clean():
+    hardware_problems.clear()
+    yield
+    hardware_problems.clear()
+
+
+def test_a_problem_is_queued_for_the_gui():
+    hardware_problems.report("X-T4", "Exposure settings were not applied")
+
+    assert hardware_problems.count() == 1
+    assert hardware_problems.peek()[0].source == "X-T4"
+
+
+def test_repeats_fold_into_a_count_rather_than_flooding():
+    # A failure inside a burst can fire dozens of times per second.  It must not
+    # become dozens of queued problems, or dozens of dialogs.
+    for _ in range(50):
+        hardware_problems.report("X-T4", "Exposure settings were not applied")
+
+    assert hardware_problems.count() == 1
+    assert hardware_problems.peek()[0].count == 50
+
+
+def test_distinct_problems_stay_distinct():
+    hardware_problems.report("X-T4", "Exposure settings were not applied")
+    hardware_problems.report("Fuji SDK", "Detection failed")
+
+    assert hardware_problems.count() == 2
+
+
+def test_the_queue_is_bounded():
+    for i in range(hardware_problems._MAX_PROBLEMS + 25):
+        hardware_problems.report("X-T4", f"problem {i}")
+
+    assert hardware_problems.count() == hardware_problems._MAX_PROBLEMS
+
+
+def test_draining_empties_the_queue():
+    hardware_problems.report("X-T4", "something")
+
+    assert len(hardware_problems.drain()) == 1
+    assert hardware_problems.count() == 0
+
+
+def test_peeking_does_not_empty_the_queue():
+    hardware_problems.report("X-T4", "something")
+
+    hardware_problems.peek()
+
+    assert hardware_problems.count() == 1
+
+
+def test_reporting_never_raises():
+    # This runs on worker threads and inside except blocks; if it could throw it
+    # would mask the failure it is trying to describe.
+    hardware_problems.report(None, None, detail=object(), severity="error")
+
+
+def test_summary_shows_repeat_counts():
+    for _ in range(3):
+        hardware_problems.report("X-T4", "Exposure settings were not applied")
+
+    summary = hardware_problems.summarise()
+
+    assert "Exposure settings were not applied" in summary
+    assert "x3" in summary


### PR DESCRIPTION
## Problem

When a camera fails to respond, the overview worker catches the exception, logs it, and fills the row with `N/A`:

```python
except Exception:
    logging.exception('Worker: exception while processing camera %s', camera_name)
    data.append([camera_name, 'N/A', 'N/A', 'N/A'])
```

On screen that looks identical to a camera that is simply idle. The user is left with a camera that appears connected but never fires, and nothing on screen says why. The same applies when the whole gather fails — the list is empty and nothing explains it.

For eclipse work this matters more than usual: the failure is discovered after the event, when the images are reviewed.

## Change

A small queue (`hardware_problems.py`) that any part of the application can report to, collected by the GUI on its own thread. Camera work runs on worker threads, which cannot open a dialog, so it has to go through a queue rather than a direct call — the same reason the overview already hands its results back through `_pending_data`.

Wired into the two places that currently only log: the per-camera probe failure and the whole-gather failure.

## Two rules in the presentation

**Repeats fold into a count.** A failure inside a burst can fire many times per second. One problem with `count=50`, never fifty dialogs.

**No dialog while a schedule is running.** A modal dialog blocks the UI thread at the exact moment frames are being taken, which is worse than the problem it reports. During a run the count goes in the window title; before and after, a dialog — which is when a camera can still be replugged or swapped.

## Tests

8 tests covering the queue: folding, bounding, draining vs peeking, and that reporting never raises (it runs inside `except` blocks, so if it could throw it would mask the failure it describes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dwu2e9budQMUGgrWZtoxY5