### PR TITLE
`for` command can now handle float `interval`; jobs scrolling improved

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ pip install solareclipseworkbench
 
 ```bash
 sudo apt update
-sudo apt install libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libxkbcommon-x11-0 libxcb-cursor0 libcairo2-dev python3.14-venv
+sudo apt install libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libxkbcommon-x11-0 libxcb-cursor0 libcairo2-dev python3.14-venv gstreamer1.0-plugins-good
 ```
 
 - Install gphoto2 to be able to access the cameras by executing the following line in the terminal
@@ -154,7 +154,7 @@ pip install solareclipseworkbench
 
 ```bash
 sudo apt update
-sudo apt install libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libxkbcommon-x11-0 libxcb-cursor0 libcairo2-dev python3.12-venv
+sudo apt install libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libxkbcommon-x11-0 libxcb-cursor0 libcairo2-dev python3.12-venv gstreamer1.0-plugins-good
 ```
 
 - Install gphoto2 to be able to access the cameras by executing the following line in the terminal
@@ -842,7 +842,7 @@ uv pip install PyObjC
 - Install uv by executing the following line in the terminal:
 
 ```bash
-sudo apt install curl git gstreamer1.0-plugins-base-apps
+sudo apt install curl git gstreamer1.0-plugins-base-apps gstreamer1.0-plugins-good
 curl -LsSf https://astral.sh/uv/install.sh | sh
 ```
 

--- a/src/solareclipseworkbench/gui.py
+++ b/src/solareclipseworkbench/gui.py
@@ -3372,7 +3372,7 @@ class QJobsTableView(QTableView):
             - row: Row index of the first job that will be executed next.
         """
 
-        index: QModelIndex = self.model().index(min(row + 5, self.model().rowCount(None) - 1), 0)
+        index: QModelIndex = self.model().index(min(row + 3, self.model().rowCount(None) - 1), 0)
         self.setCurrentIndex(index)
 
     def do(self, actions):

--- a/src/solareclipseworkbench/scripts.py
+++ b/src/solareclipseworkbench/scripts.py
@@ -229,7 +229,7 @@ def convert_script(filename, reference_moments) -> io.StringIO:
                 for_parts = next(csv.reader([line], skipinitialspace=True))
                 start = for_parts[1] if len(for_parts) > 1 else ""
                 stop = for_parts[2] if len(for_parts) > 2 else ""
-                interval = int(for_parts[3]) if len(for_parts) > 3 else 10
+                interval = for_parts[3] if len(for_parts) > 3 else 10
                 start_delta = for_parts[4] if len(for_parts) > 4 else "0"
                 stop_delta = for_parts[5] if len(for_parts) > 5 else "0"
                 
@@ -268,7 +268,7 @@ def convert_script(filename, reference_moments) -> io.StringIO:
 
                             output_file = convert_command(line, start, sign, time_delta, extra_comment, output_file)
 
-                            current_time = current_time + timedelta(seconds=interval)
+                            current_time = current_time + timedelta(seconds=float(interval))
                             iteration = iteration + 1
 
                         line = input_file.readline()


### PR DESCRIPTION
# Summary of the changes
- `FOR` was already treating `interval` as a float. But not `for`, which is weird. Fixed it!
- If the screen is low height, the scrolling is too aggressive, hiding not yet executed jobs. Adjusted it!

# Related issues
- none

# Test results
- Tried with my production script - it allowed me squeeze a bit more loops with a float value for the interval! (7s was problematic, 8s was wasteful, 7.2s is perfect)
- Checked if the scroll got affected on normal screens - all good!